### PR TITLE
Enforce login requirement across site

### DIFF
--- a/wp-content/mu-plugins/require-login.php
+++ b/wp-content/mu-plugins/require-login.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Plugin Name: Require Login
+ * Description: Restrict site to logged-in users by redirecting to the login page.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Redirect visitors to the login page if they are not authenticated.
+ */
+function hffmnn_require_login() {
+    if ( is_user_logged_in() || is_login_page() || wp_doing_cron() || wp_doing_ajax() || hffmnn_is_custom_login() ) {
+        return;
+    }
+
+    wp_safe_redirect( home_url( '/login' ) );
+    exit;
+}
+add_action( 'init', 'hffmnn_require_login' );
+
+/**
+ * Determine if the current request is for the login or registration pages.
+ *
+ * @return bool True when on the login or registration screen.
+ */
+function is_login_page() {
+    return in_array( $GLOBALS['pagenow'], array( 'wp-login.php', 'wp-register.php' ), true );
+}
+
+/**
+ * Determine if the current request is for the custom login page.
+ *
+ * @return bool True when visiting the custom login page.
+ */
+function hffmnn_is_custom_login() {
+    $login_path   = parse_url( home_url( '/login' ), PHP_URL_PATH );
+    $request_path = parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH );
+
+    return $request_path === $login_path;
+}

--- a/wp-content/plugins/hoffmann-kundenportal/hoffmann-kundenportal.php
+++ b/wp-content/plugins/hoffmann-kundenportal/hoffmann-kundenportal.php
@@ -27,16 +27,7 @@ function hoffmann_create_customer_role() {
     );
 }
 
-// 2. Umleitung zur Login-Seite für nicht eingeloggte Benutzer auf /login
-add_action('template_redirect', 'hoffmann_redirect_to_custom_login');
-function hoffmann_redirect_to_custom_login() {
-    if (!is_user_logged_in() && !is_page('login')) {
-        wp_redirect(home_url('/login'));
-        exit;
-    }
-}
-
-// 3. Benutzer aus der JSON-Datei hinzufügen oder aktualisieren
+// 2. Benutzer aus der JSON-Datei hinzufügen oder aktualisieren
 function hoffmann_update_customers_from_json() {
     if (!file_exists(KUNDEN_JSON_PATH)) {
         error_log('Kunden JSON-Datei nicht gefunden.');
@@ -87,7 +78,7 @@ function hoffmann_update_customers_from_json() {
     }
 }
 
-// 4. Benutzerdefinierte Felder im Benutzerprofil anzeigen
+// 3. Benutzerdefinierte Felder im Benutzerprofil anzeigen
 add_action('show_user_profile', 'hoffmann_show_custom_user_fields');
 add_action('edit_user_profile', 'hoffmann_show_custom_user_fields');
 function hoffmann_show_custom_user_fields($user) {
@@ -112,7 +103,7 @@ function hoffmann_show_custom_user_fields($user) {
     }
 }
 
-// 5. Cronjob für die Aktualisierung der Kunden aus der JSON-Datei alle 30 Minuten
+// 4. Cronjob für die Aktualisierung der Kunden aus der JSON-Datei alle 30 Minuten
 add_filter('cron_schedules', 'hoffmann_add_cron_interval');
 function hoffmann_add_cron_interval($schedules) {
     $schedules['thirty_minutes'] = [
@@ -130,7 +121,7 @@ function hoffmann_schedule_customer_update() {
 }
 add_action('hoffmann_update_customers_event', 'hoffmann_update_customers_from_json');
 
-// 6. Rolle "Kunde" auf das Frontend beschränken und nach dem Login zur Startseite weiterleiten
+// 5. Rolle "Kunde" auf das Frontend beschränken und nach dem Login zur Startseite weiterleiten
 add_action('init', 'hoffmann_restrict_kunde_backend_access');
 function hoffmann_restrict_kunde_backend_access() {
     if (current_user_can('kunde') && is_admin()) {
@@ -139,7 +130,7 @@ function hoffmann_restrict_kunde_backend_access() {
     }
 }
 
-// 7. Cronjob bei Deaktivierung entfernen
+// 6. Cronjob bei Deaktivierung entfernen
 register_deactivation_hook(__FILE__, 'hoffmann_remove_cron');
 function hoffmann_remove_cron() {
     $timestamp = wp_next_scheduled('hoffmann_update_customers_event');


### PR DESCRIPTION
## Summary
- Redirect unauthenticated visitors to custom `/login` page via mu-plugin
- Remove redundant login redirection logic from Hoffmann Kundenportal plugin

## Testing
- `php -l wp-content/mu-plugins/require-login.php`
- `php -l wp-content/plugins/hoffmann-kundenportal/hoffmann-kundenportal.php`


------
https://chatgpt.com/codex/tasks/task_e_68a514913c848327a62dfc69ee477026