### PR TITLE
Move login enforcement into plugin

### DIFF
--- a/wp-content/plugins/hoffmann-kundenportal/hoffmann-kundenportal.php
+++ b/wp-content/plugins/hoffmann-kundenportal/hoffmann-kundenportal.php
@@ -11,6 +11,8 @@ Version: 1.7
 Author: Max Florian Krauss
 */
 
+require_once __DIR__ . '/require-login.php';
+
 define('KUNDEN_JSON_PATH', WP_CONTENT_DIR . '/uploads/json/kunden.json');
 
 // 1. Rolle "Kunde" erstellen, wenn das Plugin aktiviert wird

--- a/wp-content/plugins/hoffmann-kundenportal/require-login.php
+++ b/wp-content/plugins/hoffmann-kundenportal/require-login.php
@@ -36,8 +36,8 @@ function is_login_page() {
  * @return bool True when visiting the custom login page.
  */
 function hffmnn_is_custom_login() {
-    $login_path   = parse_url( home_url( '/login' ), PHP_URL_PATH );
-    $request_path = parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH );
+    $login_path   = untrailingslashit( parse_url( home_url( '/login' ), PHP_URL_PATH ) );
+    $request_path = untrailingslashit( parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH ) );
 
     return $request_path === $login_path;
 }


### PR DESCRIPTION
## Summary
- relocate login requirement logic to Hoffmann Kundenportal plugin
- include require-login.php from plugin and normalize login path with `untrailingslashit`
- remove mu-plugin to prevent duplicate execution

## Testing
- `php -l wp-content/plugins/hoffmann-kundenportal/require-login.php`
- `php -l wp-content/plugins/hoffmann-kundenportal/hoffmann-kundenportal.php`


------
https://chatgpt.com/codex/tasks/task_e_68a5198e4a748327a6eb913898fbf380