### PR TITLE
Fix fatal error by guarding debug helper

### DIFF
--- a/wp-content/plugins/hoffmann-kundenportal/hoffmann-belege.php
+++ b/wp-content/plugins/hoffmann-kundenportal/hoffmann-belege.php
@@ -12,9 +12,11 @@ if (!defined('ABSPATH')) {
 
 
 // Debugging-Funktion
-function hoffmann_debug_log($message) {
-    if (defined('WP_DEBUG') && WP_DEBUG === true) {
-        error_log($message);
+if (!function_exists('hoffmann_debug_log')) {
+    function hoffmann_debug_log($message) {
+        if (defined('WP_DEBUG') && WP_DEBUG === true) {
+            error_log($message);
+        }
     }
 }
 

--- a/wp-content/plugins/hoffmann-kundenportal/hoffmann-bestellungen.php
+++ b/wp-content/plugins/hoffmann-kundenportal/hoffmann-bestellungen.php
@@ -11,9 +11,11 @@ if (!defined('ABSPATH')) {
 }
 
 // Debugging-Funktion
-function hoffmann_debug_log($message) {
-    if (defined('WP_DEBUG') && WP_DEBUG === true) {
-        error_log($message);
+if (!function_exists('hoffmann_debug_log')) {
+    function hoffmann_debug_log($message) {
+        if (defined('WP_DEBUG') && WP_DEBUG === true) {
+            error_log($message);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Avoid redeclaration of `hoffmann_debug_log` in Belege and Bestellungen importers
- Bestellungen importer continues to handle Vorbelegnummer for hierarchical posts

## Testing
- `php -l wp-content/plugins/hoffmann-kundenportal/hoffmann-bestellungen.php`
- `php -l wp-content/plugins/hoffmann-kundenportal/hoffmann-belege.php`


------
https://chatgpt.com/codex/tasks/task_e_68a52a102a308327b4301f7009aa5b85