### PR TITLE
Link Vorbeleg columns and remove posts/comments

### DIFF
--- a/wp-content/plugins/hoffmann-kundenportal/hoffmann-belege.php
+++ b/wp-content/plugins/hoffmann-kundenportal/hoffmann-belege.php
@@ -12,9 +12,11 @@ if (!defined('ABSPATH')) {
 
 
 // Debugging-Funktion
-function hoffmann_debug_log($message) {
-    if (defined('WP_DEBUG') && WP_DEBUG === true) {
-        error_log($message);
+if (!function_exists('hoffmann_debug_log')) {
+    function hoffmann_debug_log($message) {
+        if (defined('WP_DEBUG') && WP_DEBUG === true) {
+            error_log($message);
+        }
     }
 }
 
@@ -207,6 +209,14 @@ add_action('manage_belege_posts_custom_column','hoffmann_belege_custom_column',1
 function hoffmann_belege_custom_column($column,$post_id) {
     if ($column==='vorbeleg') {
         $val = get_post_meta($post_id,'vorbeleg',true);
-        echo esc_html($val);
+        if ($val) {
+            $parent = get_page_by_title($val, OBJECT, 'belege');
+            if ($parent) {
+                $link = get_edit_post_link($parent->ID);
+                echo '<a href="' . esc_url($link) . '">' . esc_html($val) . '</a>';
+            } else {
+                echo esc_html($val);
+            }
+        }
     }
 }

--- a/wp-content/plugins/hoffmann-kundenportal/hoffmann-bestellungen.php
+++ b/wp-content/plugins/hoffmann-kundenportal/hoffmann-bestellungen.php
@@ -11,9 +11,11 @@ if (!defined('ABSPATH')) {
 }
 
 // Debugging-Funktion
-function hoffmann_debug_log($message) {
-    if (defined('WP_DEBUG') && WP_DEBUG === true) {
-        error_log($message);
+if (!function_exists('hoffmann_debug_log')) {
+    function hoffmann_debug_log($message) {
+        if (defined('WP_DEBUG') && WP_DEBUG === true) {
+            error_log($message);
+        }
     }
 }
 
@@ -217,6 +219,14 @@ add_action('manage_bestellungen_posts_custom_column','hoffmann_bestellungen_cust
 function hoffmann_bestellungen_custom_column($column,$post_id) {
     if ($column==='vorbeleg') {
         $val = get_post_meta($post_id,'vorbeleg',true);
-        echo esc_html($val);
+        if ($val) {
+            $parent = get_page_by_title($val, OBJECT, 'bestellungen');
+            if ($parent) {
+                $link = get_edit_post_link($parent->ID);
+                echo '<a href="' . esc_url($link) . '">' . esc_html($val) . '</a>';
+            } else {
+                echo esc_html($val);
+            }
+        }
     }
 }

--- a/wp-content/plugins/hoffmann-kundenportal/hoffmann-kundenportal.php
+++ b/wp-content/plugins/hoffmann-kundenportal/hoffmann-kundenportal.php
@@ -171,3 +171,31 @@ function hoffmann_logout_link() {
     return '<a class="button hoffmann-logout" href="' . esc_url( $logout_url ) . '">Logout</a>';
 }
 
+// Standard-Beiträge und Kommentare entfernen
+add_action('admin_menu','hoffmann_remove_default_content');
+function hoffmann_remove_default_content() {
+    remove_menu_page('edit.php');
+    remove_menu_page('edit-comments.php');
+}
+
+add_action('init','hoffmann_disable_posts_and_comments',100);
+function hoffmann_disable_posts_and_comments() {
+    if (function_exists('unregister_post_type') && post_type_exists('post')) {
+        unregister_post_type('post');
+    }
+    foreach (get_post_types() as $pt) {
+        if (post_type_supports($pt,'comments')) {
+            remove_post_type_support($pt,'comments');
+            remove_post_type_support($pt,'trackbacks');
+        }
+    }
+}
+
+add_filter('comments_open','__return_false',20,2);
+add_filter('pings_open','__return_false',20,2);
+add_filter('comments_array','__return_empty_array',10,2);
+
+add_action('admin_bar_menu',function($bar){
+    $bar->remove_node('comments');
+},999);
+


### PR DESCRIPTION
## Summary
- Avoid redeclaration of `hoffmann_debug_log` in Belege and Bestellungen importers
- Bestellungen importer continues to handle Vorbelegnummer for hierarchical posts
- Link Vorbelegnummer column entries to referenced posts in Belege and Bestellungen
- Remove default posts and comments from admin

## Testing
- `php -l wp-content/plugins/hoffmann-kundenportal/hoffmann-belege.php`
- `php -l wp-content/plugins/hoffmann-kundenportal/hoffmann-bestellungen.php`
- `php -l wp-content/plugins/hoffmann-kundenportal/hoffmann-kundenportal.php`


------
https://chatgpt.com/codex/tasks/task_e_68a52a102a308327b4301f7009aa5b85