### PR TITLE
Show product details for orders and add frontend overview

### DIFF
--- a/wp-content/plugins/hoffmann-kundenportal/hoffmann-belege.php
+++ b/wp-content/plugins/hoffmann-kundenportal/hoffmann-belege.php
@@ -10,6 +10,8 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+require_once __DIR__ . '/lib/produkte-metabox.php';
+
 
 // Debugging-Funktion
 if (!function_exists('hoffmann_debug_log')) {
@@ -268,29 +270,6 @@ function hoffmann_belege_meta_box($post){
     foreach($fields as $key=>$label){
         $val = esc_html(get_post_meta($post->ID,$key,true));
         echo '<tr><th>'.esc_html($label).'</th><td>'.$val.'</td></tr>';
-    }
-    echo '</tbody></table>';
-
-    if (function_exists('get_field')) {
-        $produkte = get_field('produkte', $post->ID);
-        if ($produkte) {
-            echo '<h4>'.esc_html__('Produkte').'</h4>';
-            echo '<table class="widefat striped"><thead><tr>';
-            echo '<th>'.esc_html__('Artikelnummer').'</th>';
-            echo '<th>'.esc_html__('Artikelbeschreibung').'</th>';
-            echo '<th>'.esc_html__('Menge').'</th>';
-            echo '<th>'.esc_html__('Preis').'</th>';
-            echo '</tr></thead><tbody>';
-            foreach ($produkte as $prod) {
-                echo '<tr>';
-                echo '<td>'.esc_html($prod['artikelnummer']).'</td>';
-                echo '<td>'.esc_html($prod['artikelbeschreibung']).'</td>';
-                echo '<td>'.esc_html($prod['menge']).'</td>';
-                echo '<td>'.esc_html($prod['preis']).'</td>';
-                echo '</tr>';
-            }
-            echo '</tbody></table>';
-        }
     }
     echo '</tbody></table>';
 }

--- a/wp-content/plugins/hoffmann-kundenportal/lib/produkte-metabox.php
+++ b/wp-content/plugins/hoffmann-kundenportal/lib/produkte-metabox.php
@@ -1,0 +1,52 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (!function_exists('hoffmann_add_produkte_metabox')) {
+    function hoffmann_add_produkte_metabox() {
+        add_meta_box(
+            'hoffmann_produkte_metabox',
+            __('Produkte'),
+            'hoffmann_render_produkte_metabox',
+            ['belege', 'bestellungen'],
+            'normal',
+            'default'
+        );
+    }
+    add_action('add_meta_boxes', 'hoffmann_add_produkte_metabox');
+}
+
+if (!function_exists('hoffmann_render_produkte_metabox')) {
+    function hoffmann_render_produkte_metabox($post) {
+        if (!function_exists('get_field')) {
+            echo '<p>' . esc_html__('Advanced Custom Fields erforderlich.', 'hoffmann') . '</p>';
+            return;
+        }
+        $rows = get_field('produkte', $post->ID);
+        if (empty($rows)) {
+            echo '<p>' . esc_html__('Keine Produkte vorhanden.', 'hoffmann') . '</p>';
+            return;
+        }
+        echo '<table class="widefat fixed"><thead><tr>';
+        echo '<th>' . esc_html__('Artikelnummer', 'hoffmann') . '</th>';
+        echo '<th>' . esc_html__('Beschreibung', 'hoffmann') . '</th>';
+        echo '<th>' . esc_html__('Menge', 'hoffmann') . '</th>';
+        echo '<th>' . esc_html__('Preis', 'hoffmann') . '</th>';
+        echo '</tr></thead><tbody>';
+        foreach ($rows as $row) {
+            $nummer = isset($row['artikelnummer']) ? $row['artikelnummer'] : '';
+            $beschreibung = isset($row['artikelbeschreibung']) ? $row['artikelbeschreibung'] : '';
+            $menge = isset($row['menge']) ? $row['menge'] : '';
+            $preis = isset($row['preis']) ? $row['preis'] : '';
+            echo '<tr>';
+            echo '<td>' . esc_html($nummer) . '</td>';
+            echo '<td>' . esc_html($beschreibung) . '</td>';
+            echo '<td>' . esc_html($menge) . '</td>';
+            echo '<td>' . esc_html($preis) . '</td>';
+            echo '</tr>';
+        }
+        echo '</tbody></table>';
+    }
+}
+?>


### PR DESCRIPTION
## Summary
- Display ACF repeater "Produkte" as an admin metabox for Belege and Bestellungen
- Store extended metadata for Bestellungen and expose it in the admin
- Provide `[bestellungen_uebersicht]` shortcode rendering sortable parent orders with expandable child rows

## Testing
- `php -l wp-content/plugins/hoffmann-kundenportal/lib/produkte-metabox.php`
- `php -l wp-content/plugins/hoffmann-kundenportal/hoffmann-belege.php`
- `php -l wp-content/plugins/hoffmann-kundenportal/hoffmann-bestellungen.php`


------
https://chatgpt.com/codex/tasks/task_e_68a537274ac883279f23ae7ee5f189aa