### PR TITLE
Handle nested product meta and add order detail popups

### DIFF
--- a/wp-content/plugins/hoffmann-kundenportal/hoffmann-belege.php
+++ b/wp-content/plugins/hoffmann-kundenportal/hoffmann-belege.php
@@ -107,20 +107,8 @@ function hoffmann_import_belege_from_json() {
                     }
                 }
                 hoffmann_debug_log("Beleg aktualisiert: ID {$post_id}, Nummer {$belegnummer}");
-                // Produkte in Repeater-Feld aktualisieren (ACF)
-                if (function_exists('update_field')) {
-                    $rows = array();
-                    if (isset($beleg['Produkte']) && is_array($beleg['Produkte'])) {
-                        foreach ($beleg['Produkte'] as $prod) {
-                            $rows[] = array(
-                                'artikelnummer'          => sanitize_text_field($prod['Artikelnummer']),
-                                'artikelbeschreibung'    => sanitize_text_field($prod['Bezeichnung']),
-                                'menge'                  => intval($prod['Menge']),
-                                'preis'                  => sanitize_text_field($prod['Einzelpreis']),
-                            );
-                        }
-                    }
-                    update_field('produkte', $rows, $post_id);
+                if (isset($beleg['Produkte'])) {
+                    update_post_meta($post_id, 'produkte', wp_json_encode($beleg['Produkte']));
                 }
             }
         } else {
@@ -137,6 +125,7 @@ function hoffmann_import_belege_from_json() {
                     'vorbeleg'        => $vorbelegnummer,
                     'air_cargo_kosten'   => $air_cargo,
                     'zoll_abwicklung_kosten' => $zoll_kosten,
+                    'produkte'        => isset($beleg['Produkte']) ? wp_json_encode($beleg['Produkte']) : '',
                 ),
             );
             if (!empty($vorbelegnummer)) {
@@ -154,21 +143,9 @@ function hoffmann_import_belege_from_json() {
                 }
                 wp_set_object_terms($post_id, $belegart_term, 'belegart');
                 hoffmann_debug_log("Neuer Beleg erstellt: ID {$post_id}, Nummer {$belegnummer}");
-            // Produkte in Repeater-Feld speichern (ACF)
-            if (function_exists('update_field')) {
-                $rows = array();
-                if (isset($beleg['Produkte']) && is_array($beleg['Produkte'])) {
-                    foreach ($beleg['Produkte'] as $prod) {
-                        $rows[] = array(
-                            'artikelnummer'          => sanitize_text_field($prod['Artikelnummer']),
-                            'artikelbeschreibung'    => sanitize_text_field($prod['Bezeichnung']),
-                            'menge'                  => intval($prod['Menge']),
-                            'preis'                  => sanitize_text_field($prod['Einzelpreis']),
-                        );
-                    }
+                if (isset($beleg['Produkte'])) {
+                    update_post_meta($post_id, 'produkte', wp_json_encode($beleg['Produkte']));
                 }
-                update_field('produkte', $rows, $post_id);
-            }
             } else {
                 hoffmann_debug_log("Fehler beim Erstellen des Belegs: {$belegnummer}");
             }

--- a/wp-content/plugins/hoffmann-kundenportal/lib/produkte-metabox.php
+++ b/wp-content/plugins/hoffmann-kundenportal/lib/produkte-metabox.php
@@ -19,34 +19,58 @@ if (!function_exists('hoffmann_add_produkte_metabox')) {
 
 if (!function_exists('hoffmann_render_produkte_metabox')) {
     function hoffmann_render_produkte_metabox($post) {
-        if (!function_exists('get_field')) {
-            echo '<p>' . esc_html__('Advanced Custom Fields erforderlich.', 'hoffmann') . '</p>';
-            return;
-        }
-        $rows = get_field('produkte', $post->ID);
-        if (empty($rows)) {
+        $data = get_post_meta($post->ID, 'produkte', true);
+        if (!$data) {
             echo '<p>' . esc_html__('Keine Produkte vorhanden.', 'hoffmann') . '</p>';
             return;
         }
+        if (!is_array($data)) {
+            $data = json_decode($data, true);
+        }
+        if (empty($data)) {
+            echo '<p>' . esc_html__('Keine Produkte vorhanden.', 'hoffmann') . '</p>';
+            return;
+        }
+
         echo '<table class="widefat fixed"><thead><tr>';
         echo '<th>' . esc_html__('Artikelnummer', 'hoffmann') . '</th>';
         echo '<th>' . esc_html__('Beschreibung', 'hoffmann') . '</th>';
         echo '<th>' . esc_html__('Menge', 'hoffmann') . '</th>';
         echo '<th>' . esc_html__('Preis', 'hoffmann') . '</th>';
         echo '</tr></thead><tbody>';
-        foreach ($rows as $row) {
-            $nummer = isset($row['artikelnummer']) ? $row['artikelnummer'] : '';
-            $beschreibung = isset($row['artikelbeschreibung']) ? $row['artikelbeschreibung'] : '';
-            $menge = isset($row['menge']) ? $row['menge'] : '';
-            $preis = isset($row['preis']) ? $row['preis'] : '';
-            echo '<tr>';
-            echo '<td>' . esc_html($nummer) . '</td>';
-            echo '<td>' . esc_html($beschreibung) . '</td>';
-            echo '<td>' . esc_html($menge) . '</td>';
-            echo '<td>' . esc_html($preis) . '</td>';
-            echo '</tr>';
-        }
+        echo hoffmann_render_produkte_rows($data);
         echo '</tbody></table>';
+    }
+}
+
+if (!function_exists('hoffmann_render_produkte_rows')) {
+    function hoffmann_render_produkte_rows($items, $level = 0) {
+        $html = '';
+        if (!is_array($items)) {
+            return $html;
+        }
+        foreach ($items as $item) {
+            if (!is_array($item)) {
+                continue;
+            }
+            $nummer = isset($item['Artikelnummer']) ? $item['Artikelnummer'] : '';
+            $beschreibung = isset($item['Bezeichnung']) ? $item['Bezeichnung'] : '';
+            $menge = isset($item['Menge']) ? $item['Menge'] : '';
+            $preis = isset($item['Einzelpreis']) ? $item['Einzelpreis'] : '';
+            $pad = str_repeat('&nbsp;', $level * 4);
+            $html .= '<tr>';
+            $html .= '<td>' . esc_html($nummer) . '</td>';
+            $html .= '<td>' . $pad . esc_html($beschreibung) . '</td>';
+            $html .= '<td>' . esc_html($menge) . '</td>';
+            $html .= '<td>' . esc_html($preis) . '</td>';
+            $html .= '</tr>';
+            foreach ($item as $key => $val) {
+                if (is_array($val)) {
+                    $html .= hoffmann_render_produkte_rows($val, $level + 1);
+                }
+            }
+        }
+        return $html;
     }
 }
 ?>


### PR DESCRIPTION
## Summary
- Store Produkte meta as raw JSON for orders and documents
- Recursively render nested product structures in metabox
- Add detail popups for sub orders with editable Aircargo and Zoll costs

## Testing
- `php -l wp-content/plugins/hoffmann-kundenportal/lib/produkte-metabox.php`
- `php -l wp-content/plugins/hoffmann-kundenportal/hoffmann-bestellungen.php`
- `php -l wp-content/plugins/hoffmann-kundenportal/hoffmann-belege.php`


------
https://chatgpt.com/codex/tasks/task_e_68a594554fdc8327a427c534a91b660e