### PR TITLE
Fix Belege product display and order cost formatting

### DIFF
--- a/wp-content/plugins/hoffmann-kundenportal/hoffmann-belege.php
+++ b/wp-content/plugins/hoffmann-kundenportal/hoffmann-belege.php
@@ -239,8 +239,6 @@ function hoffmann_belege_meta_box($post){
         'belegstatus'           => __('Status'),
         'kundennummer'          => __('Kundennummer'),
         'betragnetto'           => __('Betrag Netto'),
-        'air_cargo_kosten'      => __('Air-Cargo-Kosten'),
-        'zoll_abwicklung_kosten'=> __('Zoll-Abwicklung-Kosten'),
         'vorbeleg'              => __('Vorbelegnummer'),
     );
     echo '<table class="form-table"><tbody>';


### PR DESCRIPTION
## Summary
- Ensure Belege detail shortcode loads products from post meta and supports multiple key names
- Drop AirCargo/Zoll fields from Belege meta box
- Avoid unwanted currency formatting for AirCargo/Zoll costs and expand order detail output with product and cost tables

## Testing
- `php -l wp-content/plugins/hoffmann-kundenportal/hoffmann-belege-anzeigen.php`
- `php -l wp-content/plugins/hoffmann-kundenportal/hoffmann-belege.php`
- `php -l wp-content/plugins/hoffmann-kundenportal/hoffmann-bestellungen.php`


------
https://chatgpt.com/codex/tasks/task_e_68a5e4208e9083279dd37bffb32a4c87