### PR TITLE
Refactor table markup and centralise plugin styles

### DIFF
--- a/wp-content/plugins/hoffmann-kundenportal/css/hoffmann-kundenportal.css
+++ b/wp-content/plugins/hoffmann-kundenportal/css/hoffmann-kundenportal.css
@@ -1,0 +1,46 @@
+.hoffmann-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.hoffmann-table th {
+    text-align: left;
+}
+
+.hoffmann-table-summary {
+    margin-top: 10px;
+}
+
+.text-right {
+    text-align: right;
+}
+
+.hoffmann-overlay {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 9998;
+}
+
+.hoffmann-popup {
+    display: none;
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: #fff;
+    padding: 20px;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+    z-index: 9999;
+    max-width: 90%;
+    max-height: 80%;
+    overflow: auto;
+}
+
+.popup-close {
+    float: right;
+}

--- a/wp-content/plugins/hoffmann-kundenportal/hoffmann-belege-anzeigen.php
+++ b/wp-content/plugins/hoffmann-kundenportal/hoffmann-belege-anzeigen.php
@@ -56,7 +56,7 @@ function hoffmann_belege_anzeigen_shortcode(){
     $q = new WP_Query($args);
 
     // Table and popups
-    $output .= '<table class="hoffmann-belege" style="width:100%;border-collapse:collapse;"><thead><tr>'
+    $output .= '<table class="hoffmann-table hoffmann-belege"><thead><tr>'
              . '<th><a href="'.$link_date.'">Datum</a></th>'
              . '<th><a href="'.$link_nr.'">Nummer</a></th>'
              . '<th>Status</th><th>Preis</th><th>Aktion</th>'
@@ -85,12 +85,9 @@ function hoffmann_belege_anzeigen_shortcode(){
 
             // Overlay + Popup HTML
             $detail_html = do_shortcode('[hoffmann_beleg_details id="'.$pid.'"]');
-            $popups .= '<div id="overlay-'.$pid.'" class="hoffmann-overlay" style="display:none;position:fixed;top:0;left:0;'
-                     . 'width:100%;height:100%;background:rgba(0,0,0,0.5);z-index:9998;"></div>';
-            $popups .= '<div id="popup-'.$pid.'" class="hoffmann-popup" style="display:none;position:fixed;top:50%;left:50%;'
-                     . 'transform:translate(-50%, -50%);background:#fff;padding:20px;box-shadow:0 0 10px rgba(0,0,0,0.5);'
-                     . 'z-index:9999;max-width:90%;max-height:80%;overflow:auto;">'
-                     . '<button class="popup-close" style="float:right;">&times;</button>'
+            $popups .= '<div id="overlay-'.$pid.'" class="hoffmann-overlay"></div>';
+            $popups .= '<div id="popup-'.$pid.'" class="hoffmann-popup">'
+                     . '<button class="popup-close">&times;</button>'
                      . $detail_html .'</div>';
         }
         wp_reset_postdata();
@@ -137,8 +134,9 @@ function hoffmann_beleg_details_shortcode($atts){
             $rows = is_array($meta) ? $meta : json_decode($meta, true);
         }
     }
+    // Mengen in Stück, Preise in € pro Stück.
     $html  = "<h3>{$ba} {$nr}</h3><p><strong>Datum:</strong> {$dt}</p>";
-    $html .= "<table style='width:100%;border-collapse:collapse;'><tr><th>Beschreibung</th><th>Menge</th><th>Preis</th></tr>";
+    $html .= "<table class='hoffmann-table'><thead><tr><th>Beschreibung</th><th>Menge</th><th>Preis</th></tr></thead><tbody>";
     $net   = 0;
     foreach($rows ?: [] as $r){
         $beschreibung = $r['Bezeichnung'] ?? $r['artikelbeschreibung'] ?? '';
@@ -152,13 +150,13 @@ function hoffmann_beleg_details_shortcode($atts){
         if ($raw_price !== '' && strpos($raw_price, '.') === false) { $raw_price = $raw_price / 100; }
         $net += (float)$raw_price * (int)$menge;
     }
-    $html .= '</table>';
+    $html .= '</tbody></table>';
     $net_f = hoffmann_format_currency($net);
     $mwst  = $net * 0.19;
     $mwst_f= hoffmann_format_currency($mwst);
     $br_f  = hoffmann_format_currency($net + $mwst);
-    $html .= "<p style='text-align:right;'><strong>Netto:</strong> {$net_f}</p>";
-    $html .= "<p style='text-align:right;'><strong>MwSt (19%):</strong> {$mwst_f}</p>";
-    $html .= "<p style='text-align:right;'><strong>Brutto:</strong> {$br_f}</p>";
+    $html .= "<p class='text-right'><strong>Netto:</strong> {$net_f}</p>";
+    $html .= "<p class='text-right'><strong>MwSt (19%):</strong> {$mwst_f}</p>";
+    $html .= "<p class='text-right'><strong>Brutto:</strong> {$br_f}</p>";
     return $html;
 }

--- a/wp-content/plugins/hoffmann-kundenportal/hoffmann-bestellungen.php
+++ b/wp-content/plugins/hoffmann-kundenportal/hoffmann-bestellungen.php
@@ -385,11 +385,13 @@ if (!function_exists('hoffmann_bestellung_detail_html')) {
         }
         $steuer_f = hoffmann_format_currency($steuer_total);
 
-        $html .= '<table style="width:100%;border-collapse:collapse;margin-top:10px;"><tbody>';
-        $html .= '<tr><th colspan="6" style="text-align:left;">'.esc_html__('Stückpreis je Produkt','hoffmann').'</th><td>'.esc_html(hoffmann_format_currency($total)).'</td></tr>';
-        $html .= '<tr><th colspan="6" style="text-align:left;">'.esc_html__('Stückpreis je AirCargo','hoffmann').'</th><td>'.esc_html($air_f).'</td></tr>';
-        $html .= '<tr><th colspan="6" style="text-align:left;">'.esc_html__('Zoll Abwicklung Stückpreis','hoffmann').'</th><td>'.esc_html($zoll_f).'</td></tr>';
-        $html .= '<tr><th colspan="6" style="text-align:left;">'.esc_html__('Steuermarken-Wert','hoffmann').'</th><td>'.esc_html($steuer_f).'</td></tr>';
+        // Preise in € pro Stück.
+        $html .= '<table class="hoffmann-table hoffmann-table-summary">';
+        $html .= '<thead><tr><th colspan="6">'.esc_html__('Kostenart','hoffmann').'</th><th>'.esc_html__('Preis','hoffmann').'</th></tr></thead><tbody>';
+        $html .= '<tr><th colspan="6">'.esc_html__('Stückpreis je Produkt','hoffmann').'</th><td>'.esc_html(hoffmann_format_currency($total)).'</td></tr>';
+        $html .= '<tr><th colspan="6">'.esc_html__('Stückpreis je AirCargo','hoffmann').'</th><td>'.esc_html($air_f).'</td></tr>';
+        $html .= '<tr><th colspan="6">'.esc_html__('Zoll Abwicklung Stückpreis','hoffmann').'</th><td>'.esc_html($zoll_f).'</td></tr>';
+        $html .= '<tr><th colspan="6">'.esc_html__('Steuermarken-Wert','hoffmann').'</th><td>'.esc_html($steuer_f).'</td></tr>';
         $html .= '</tbody></table>';
 
         $html .= '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'">';

--- a/wp-content/plugins/hoffmann-kundenportal/hoffmann-kundenportal.php
+++ b/wp-content/plugins/hoffmann-kundenportal/hoffmann-kundenportal.php
@@ -15,6 +15,17 @@ require_once __DIR__ . '/require-login.php';
 
 define('KUNDEN_JSON_PATH', WP_CONTENT_DIR . '/uploads/json/kunden.json');
 
+// Gemeinsame Styles laden
+add_action('wp_enqueue_scripts', 'hoffmann_kundenportal_enqueue_assets');
+function hoffmann_kundenportal_enqueue_assets() {
+    wp_enqueue_style(
+        'hoffmann-kundenportal',
+        plugins_url('css/hoffmann-kundenportal.css', __FILE__),
+        [],
+        '1.0.0'
+    );
+}
+
 // 1. Rolle "Kunde" erstellen, wenn das Plugin aktiviert wird
 register_activation_hook(__FILE__, 'hoffmann_create_customer_role');
 function hoffmann_create_customer_role() {


### PR DESCRIPTION
## Summary
- Add shared CSS for tables, popups and alignment
- Replace inline styles with classes and semantic table sections
- Enqueue new stylesheet in Hoffmann Kundenportal plugin

## Testing
- `php -l wp-content/plugins/hoffmann-kundenportal/hoffmann-kundenportal.php`
- `php -l wp-content/plugins/hoffmann-kundenportal/hoffmann-bestellungen.php`
- `php -l wp-content/plugins/hoffmann-kundenportal/hoffmann-belege-anzeigen.php`


------
https://chatgpt.com/codex/tasks/task_e_68a6418fae5c83279a72f251ec3955b9