### PR TITLE
feat: enhance tax stamp handling

### DIFF
--- a/wp-content/plugins/hoffmann-kundenportal/hoffmann-steuermarken.php
+++ b/wp-content/plugins/hoffmann-kundenportal/hoffmann-steuermarken.php
@@ -36,16 +36,38 @@ add_action('add_meta_boxes', 'hoffmann_steuermarken_add_meta_box');
 
 function hoffmann_steuermarken_metabox_render($post) {
     wp_nonce_field('hoffmann_steuermarken_meta', 'hoffmann_steuermarken_meta_nonce');
-    $belegnummer = get_post_meta($post->ID, 'belegnummer', true);
-    $wert        = get_post_meta($post->ID, 'wert', true);
-    $stueckzahl  = get_post_meta($post->ID, 'stueckzahl', true);
+    $kategorie   = get_post_meta($post->ID, 'kategorie', true);
+    $stueckzahl  = (int)get_post_meta($post->ID, 'stueckzahl', true);
     $bestelldatum= get_post_meta($post->ID, 'bestelldatum', true);
     $order_id    = get_post_meta($post->ID, 'bestellung_id', true);
-    $orders      = get_posts(array('post_type'=>'bestellungen', 'numberposts'=>-1, 'orderby'=>'title', 'order'=>'ASC'));
+    $orders      = get_posts(array(
+        'post_type'  => 'bestellungen',
+        'numberposts'=> -1,
+        'orderby'    => 'title',
+        'order'      => 'ASC',
+        'tax_query'  => array(array(
+            'taxonomy' => 'bestellart',
+            'field'    => 'name',
+            'terms'    => '2200',
+        ))
+    ));
+    $categories = array(
+        '0.52' => '0,52 €',
+        '1.04' => '1,04 €',
+        '2.60' => '2,60 €',
+    );
+    $stueckzahl_disp = $stueckzahl ? number_format_i18n($stueckzahl) : '';
+    $wert_calc = 0;
+    if ($kategorie !== '' && $stueckzahl) {
+        $wert_calc = (float)$kategorie * $stueckzahl;
+    }
+    $wert_disp = number_format($wert_calc, 2, ',', '.');
     ?>
-    <p><label>Steuermarken-Belegnummer<br><input type="text" name="belegnummer" value="<?php echo esc_attr($belegnummer); ?>"></label></p>
-    <p><label>Steuermarken-Wert<br><input type="text" name="wert" value="<?php echo esc_attr($wert); ?>"></label></p>
-    <p><label>Steuermarken-Stückzahl<br><input type="number" name="stueckzahl" value="<?php echo esc_attr($stueckzahl); ?>"></label></p>
+    <p><label>Kategorie<br><select name="kategorie">
+        <?php foreach($categories as $val => $label){ echo '<option value="'.esc_attr($val).'" '.selected($kategorie,$val,false).'>'.esc_html($label).'</option>'; } ?>
+    </select></label></p>
+    <p><label>Steuermarken-Stückzahl<br><input type="text" name="stueckzahl" value="<?php echo esc_attr($stueckzahl_disp); ?>"></label></p>
+    <p>Steuermarken-Warenwert: <strong><?php echo esc_html($wert_disp); ?> €</strong></p>
     <p><label>Bestelldatum<br><input type="date" name="bestelldatum" value="<?php echo esc_attr($bestelldatum); ?>"></label></p>
     <p><label>Bestellung<br><select name="bestellung_id"><option value="">-</option>
     <?php foreach($orders as $o){ echo '<option value="'.esc_attr($o->ID).'" '.selected($order_id, $o->ID, false).'>'.esc_html($o->post_title).'</option>'; } ?>
@@ -59,12 +81,38 @@ function hoffmann_steuermarken_save_meta($post_id) {
     }
     if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) return;
     if (!current_user_can('edit_post', $post_id)) return;
-    update_post_meta($post_id, 'belegnummer', sanitize_text_field($_POST['belegnummer'] ?? ''));
-    update_post_meta($post_id, 'wert', sanitize_text_field($_POST['wert'] ?? ''));
-    update_post_meta($post_id, 'stueckzahl', intval($_POST['stueckzahl'] ?? 0));
+    $kategorie  = sanitize_text_field($_POST['kategorie'] ?? '');
+    $st_raw     = sanitize_text_field($_POST['stueckzahl'] ?? '0');
+    $stueckzahl = (int) str_replace(array('.',','), '', $st_raw);
+    $wert       = ($kategorie !== '') ? (float)$kategorie * $stueckzahl : 0;
+    $wert_form  = number_format($wert, 2, ',', '.');
+    update_post_meta($post_id, 'kategorie', $kategorie);
+    update_post_meta($post_id, 'stueckzahl', $stueckzahl);
+    update_post_meta($post_id, 'wert', $wert_form);
     update_post_meta($post_id, 'bestelldatum', sanitize_text_field($_POST['bestelldatum'] ?? ''));
-    update_post_meta($post_id, 'bestellung_id', intval($_POST['bestellung_id'] ?? 0));
+    $bestellung = intval($_POST['bestellung_id'] ?? 0);
+    if ($bestellung && has_term('2200','bestellart',$bestellung)) {
+        update_post_meta($post_id, 'bestellung_id', $bestellung);
+    } else {
+        update_post_meta($post_id, 'bestellung_id', 0);
+    }
 }
 add_action('save_post_steuermarken', 'hoffmann_steuermarken_save_meta');
+
+function hoffmann_steuermarken_title_placeholder($title, $post){
+    if('steuermarken' === $post->post_type){
+        $title = __('Steuermarken-Belegnummer');
+    }
+    return $title;
+}
+add_filter('enter_title_here','hoffmann_steuermarken_title_placeholder',10,2);
+
+function hoffmann_steuermarken_columns($columns){
+    if(isset($columns['title'])){
+        $columns['title'] = __('Steuermarken-Belegnummer');
+    }
+    return $columns;
+}
+add_filter('manage_steuermarken_posts_columns','hoffmann_steuermarken_columns');
 
 ?>


### PR DESCRIPTION
## Summary
- allow assigning tax stamps only to orders of type 2200
- add selectable categories for stamp values and compute total automatically
- rename title field to "Steuermarken-Belegnummer" and format quantities with thousands separators

## Testing
- `php -l wp-content/plugins/hoffmann-kundenportal/hoffmann-steuermarken.php`

------
https://chatgpt.com/codex/tasks/task_e_68a6548815dc8327a79c90a702708609