### PR TITLE
Fix currency formatting for integer values

### DIFF
--- a/wp-content/plugins/hoffmann-kundenportal/hoffmann-bestellungen.php
+++ b/wp-content/plugins/hoffmann-kundenportal/hoffmann-bestellungen.php
@@ -722,7 +722,6 @@ function hoffmann_bestellung_single_content($content){
     foreach ($stm_posts as $s) {
         $w = str_replace('.', '', get_post_meta($s->ID,'wert',true));
         $w = str_replace(',', '.', $w);
-        if ($w !== '' && strpos($w,'.') === false) { $w /= 100; }
         $total_stm += (float)$w;
     }
     $air_per_unit   = $total_ordered > 0 ? $total_air / $total_ordered : 0;
@@ -835,15 +834,12 @@ function hoffmann_bestellungen_dashboard_page(){
     foreach($orders as $o){
         $net = str_replace('.', '', get_post_meta($o->ID,'betragnetto',true));
         $net = str_replace(',', '.', $net);
-        if ($net !== '' && strpos($net,'.') === false) { $net /= 100; }
         $total_netto += (float)$net;
         $air = str_replace('.', '', get_post_meta($o->ID,'air_cargo_kosten',true));
         $air = str_replace(',', '.', $air);
-        if ($air !== '' && strpos($air,'.') === false) { $air /= 100; }
         $total_air += (float)$air;
         $zoll = str_replace('.', '', get_post_meta($o->ID,'zoll_abwicklung_kosten',true));
         $zoll = str_replace(',', '.', $zoll);
-        if ($zoll !== '' && strpos($zoll,'.') === false) { $zoll /= 100; }
         $total_zoll += (float)$zoll;
     }
     $stm_posts = get_posts(array('post_type'=>'steuermarken','numberposts'=>-1));
@@ -851,7 +847,6 @@ function hoffmann_bestellungen_dashboard_page(){
     foreach($stm_posts as $s){
         $w = str_replace('.', '', get_post_meta($s->ID,'wert',true));
         $w = str_replace(',', '.', $w);
-        if ($w !== '' && strpos($w,'.') === false) { $w /= 100; }
         $total_stm += (float)$w;
     }
     ?>

--- a/wp-content/plugins/hoffmann-kundenportal/lib/produkte-metabox.php
+++ b/wp-content/plugins/hoffmann-kundenportal/lib/produkte-metabox.php
@@ -10,9 +10,6 @@ if (!function_exists('hoffmann_format_currency')) {
         }
         $value = str_replace('.', '', $value);
         $value = str_replace(',', '.', $value);
-        if (strpos((string) $value, '.') === false && is_numeric($value)) {
-            $value = $value / 100;
-        }
         return number_format((float) $value, 2, ',', '.');
     }
 }


### PR DESCRIPTION
## Summary
- stop dividing whole-number amounts by 100 in `hoffmann_format_currency`
- remove cent-to-euro conversions when summing totals in `hoffmann-bestellungen.php`

## Testing
- `php -l wp-content/plugins/hoffmann-kundenportal/lib/produkte-metabox.php`
- `php -l wp-content/plugins/hoffmann-kundenportal/hoffmann-bestellungen.php`
- `php -r "define('ABSPATH', __DIR__); function add_meta_box(){} function add_action(){} function esc_html__($t){return $t;} function esc_html($t){return $t;} function number_format_i18n($n){return $n;} include 'wp-content/plugins/hoffmann-kundenportal/lib/produkte-metabox.php'; echo hoffmann_format_currency(10400) . ' €' . PHP_EOL; echo hoffmann_format_currency(10000) . ' €' . PHP_EOL;"`

------
https://chatgpt.com/codex/tasks/task_e_68a65769050c8327a0ff880e23423d77