### PR TITLE
Ensure numeric fields use floats

### DIFF
--- a/wp-content/plugins/hoffmann-kundenportal/hoffmann-belege.php
+++ b/wp-content/plugins/hoffmann-kundenportal/hoffmann-belege.php
@@ -11,6 +11,7 @@ if (!defined('ABSPATH')) {
 }
 
 require_once __DIR__ . '/lib/produkte-metabox.php';
+require_once __DIR__ . '/lib/number-utils.php';
 
 
 // Debugging-Funktion
@@ -73,10 +74,10 @@ function hoffmann_import_belege_from_json() {
         $belegdatum   = $beleg['Metadaten']['Belegdatum'];
         $belegstatus  = $beleg['Metadaten']['Belegstatus'];
         $kundennummer = $beleg['Metadaten']['Kundennummer'];
-        $betragnetto  = $beleg['Metadaten']['BetragNetto'];
+        $betragnetto  = hoffmann_to_float($beleg['Metadaten']['BetragNetto']);
         $vorbelegnummer = $beleg['Metadaten']['Vorbelegnummer'];
-        $air_cargo    = isset($beleg['Metadaten']['AirCargoKosten']) ? $beleg['Metadaten']['AirCargoKosten'] : '';
-        $zoll_kosten  = isset($beleg['Metadaten']['ZollAbwicklungKosten']) ? $beleg['Metadaten']['ZollAbwicklungKosten'] : '';
+        $air_cargo    = isset($beleg['Metadaten']['AirCargoKosten']) ? hoffmann_to_float($beleg['Metadaten']['AirCargoKosten']) : 0.0;
+        $zoll_kosten  = isset($beleg['Metadaten']['ZollAbwicklungKosten']) ? hoffmann_to_float($beleg['Metadaten']['ZollAbwicklungKosten']) : 0.0;
         $belegart_term = $beleg['Metadaten']['Belegart'];
 
         // Vorhandene Posts prüfen

--- a/wp-content/plugins/hoffmann-kundenportal/hoffmann-steuermarken.php
+++ b/wp-content/plugins/hoffmann-kundenportal/hoffmann-steuermarken.php
@@ -10,6 +10,8 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+require_once __DIR__ . '/lib/number-utils.php';
+
 function hoffmann_register_steuermarken_post_type() {
     register_post_type('steuermarken', array(
         'labels' => array(
@@ -36,7 +38,7 @@ add_action('add_meta_boxes', 'hoffmann_steuermarken_add_meta_box');
 
 function hoffmann_steuermarken_metabox_render($post) {
     wp_nonce_field('hoffmann_steuermarken_meta', 'hoffmann_steuermarken_meta_nonce');
-    $kategorie   = get_post_meta($post->ID, 'kategorie', true);
+    $kategorie   = hoffmann_to_float(get_post_meta($post->ID, 'kategorie', true));
     $stueckzahl  = (int)get_post_meta($post->ID, 'stueckzahl', true);
     $bestelldatum= get_post_meta($post->ID, 'bestelldatum', true);
     $order_id    = get_post_meta($post->ID, 'bestellung_id', true);
@@ -58,8 +60,8 @@ function hoffmann_steuermarken_metabox_render($post) {
     );
     $stueckzahl_disp = $stueckzahl ? $stueckzahl : '';
     $wert_calc = 0;
-    if ($kategorie !== '' && $stueckzahl) {
-        $wert_calc = (float)$kategorie * $stueckzahl;
+    if ($kategorie !== 0 && $stueckzahl) {
+        $wert_calc = $kategorie * $stueckzahl;
     }
     $wert_disp = $wert_calc;
     ?>
@@ -81,10 +83,10 @@ function hoffmann_steuermarken_save_meta($post_id) {
     }
     if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) return;
     if (!current_user_can('edit_post', $post_id)) return;
-    $kategorie  = sanitize_text_field($_POST['kategorie'] ?? '');
+    $kategorie  = hoffmann_to_float($_POST['kategorie'] ?? '');
     $st_raw     = sanitize_text_field($_POST['stueckzahl'] ?? '0');
     $stueckzahl = (int) $st_raw;
-    $wert       = ($kategorie !== '') ? (float)$kategorie * $stueckzahl : 0;
+    $wert       = ($kategorie !== '') ? $kategorie * $stueckzahl : 0;
     update_post_meta($post_id, 'kategorie', $kategorie);
     update_post_meta($post_id, 'stueckzahl', $stueckzahl);
     update_post_meta($post_id, 'wert', $wert);

--- a/wp-content/plugins/hoffmann-kundenportal/lib/number-utils.php
+++ b/wp-content/plugins/hoffmann-kundenportal/lib/number-utils.php
@@ -1,0 +1,14 @@
+<?php
+if (!function_exists('hoffmann_to_float')) {
+    function hoffmann_to_float($value) {
+        if (is_string($value)) {
+            $value = str_replace([' ', "\xC2\xA0"], '', $value); // remove spaces & NBSP
+            if (strpos($value, ',') !== false) {
+                $value = str_replace('.', '', $value); // remove thousand separators
+                $value = str_replace(',', '.', $value);
+            }
+        }
+        return floatval($value);
+    }
+}
+?>


### PR DESCRIPTION
## Summary
- add `hoffmann_to_float` helper for reliable numeric parsing
- normalize Belege and Bestellungen cost fields to floats
- handle Steuermarken values as floats to prevent calculation errors

## Testing
- `php -l wp-content/plugins/hoffmann-kundenportal/lib/number-utils.php`
- `php -l wp-content/plugins/hoffmann-kundenportal/hoffmann-belege.php`
- `php -l wp-content/plugins/hoffmann-kundenportal/hoffmann-bestellungen.php`
- `php -l wp-content/plugins/hoffmann-kundenportal/hoffmann-steuermarken.php`


------
https://chatgpt.com/codex/tasks/task_e_68a709407b7c8327aeff598ba46c0d78