### PR TITLE
Clear output buffer before sending Excel headers

### DIFF
--- a/wp-content/plugins/hoffmann-kundenportal/hoffmann-products.php
+++ b/wp-content/plugins/hoffmann-kundenportal/hoffmann-products.php
@@ -373,6 +373,7 @@ function hoffmann_export_loop_grid_excel() {
     }
 
     // Header für den Excel-Download
+    if (ob_get_length()) { ob_end_clean(); }
     header('Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
     header('Content-Disposition: attachment;filename="produkte_export.xlsx"');
     header('Cache-Control: max-age=0');


### PR DESCRIPTION
## Summary
- clear output buffering before sending Excel headers in export

## Testing
- `php -l wp-content/plugins/hoffmann-kundenportal/hoffmann-products.php`


------
https://chatgpt.com/codex/tasks/task_e_68a7440c7910832792148be54c7a8f59