### PR TITLE
Add offene Posten list page

### DIFF
--- a/offene-posten.html
+++ b/offene-posten.html
@@ -1,0 +1,275 @@
+<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Offene Posten – Übersicht</title>
+  <style>
+    :root{
+      --bg:#f7fafc;--fg:#0f172a;--muted:#6b7280;--line:#e5e7eb;--card:#ffffff;--accent:#2563eb;--warn:#eab308;--danger:#dc2626;--ok:#16a34a;--radius:14px;--shadow:0 6px 24px rgba(2,6,23,.06)
+    }
+    *{box-sizing:border-box}
+    body{margin:0;background:var(--bg);font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial;color:var(--fg)}
+    .wrap{max-width:1280px;margin:36px auto;padding:0 20px}
+    h1{margin:0 0 6px;font-size:28px;font-weight:700}
+    .sub{color:var(--muted);font-size:14px}
+
+    .toolbar{display:flex;flex-wrap:wrap;gap:10px;margin:18px 0}
+    .input,select,.btn{border:1px solid var(--line);background:#fff;border-radius:10px;height:40px;padding:8px 12px;font-size:14px}
+    .btn{cursor:pointer}
+    .btn.primary{background:var(--accent);border-color:var(--accent);color:#fff}
+
+    .grid{display:grid;gap:16px}
+    .grid-4{grid-template-columns:repeat(4,1fr)}
+    @media (max-width:1024px){.grid-4{grid-template-columns:repeat(2,1fr)}}
+    @media (max-width:640px){.grid-4{grid-template-columns:1fr}}
+
+    .kpi{background:var(--card);border:1px solid var(--line);border-radius:var(--radius);box-shadow:var(--shadow);padding:16px}
+    .kpi .label{font-size:12px;color:var(--muted)}
+    .kpi .val{font-size:22px;font-weight:700;margin-top:6px}
+
+    .layout{display:grid;grid-template-columns:2fr 1fr;gap:16px}
+    @media (max-width:1024px){.layout{grid-template-columns:1fr}}
+
+    .card{background:var(--card);border:1px solid var(--line);border-radius:var(--radius);box-shadow:var(--shadow)}
+    .card h2{margin:0;padding:14px 16px;border-bottom:1px solid var(--line);font-size:15px;color:#374151}
+    .card .body{padding:16px}
+
+    .table{overflow:auto;border-radius:var(--radius);border:1px solid var(--line);background:#fff}
+    table{width:100%;border-collapse:collapse;font-size:14px}
+    th,td{padding:12px 14px;border-top:1px solid var(--line);text-align:left}
+    thead th{position:sticky;top:0;background:#f3f4f6;text-transform:uppercase;font-size:11px;letter-spacing:.06em;color:#6b7280;z-index:1}
+    tbody tr:nth-child(odd){background:#fbfdff}
+    .right{text-align:right}
+
+    .muted{color:var(--muted);font-size:13px}
+
+    .pill{display:inline-block;padding:4px 8px;border-radius:999px;border:1px solid var(--line);font-size:11px;color:#374151;background:#f8fafc}
+    .pill.warn{background:#fffbeb;border-color:#fde68a;color:#92400e}
+    .pill.danger{background:#fef2f2;border-color:#fecaca;color:#991b1b}
+
+    .totals{display:grid;grid-template-columns:1fr;gap:8px}
+    .total-row{display:flex;justify-content:space-between;align-items:center;border:1px solid var(--line);background:#fff;padding:10px 12px;border-radius:10px}
+    .total-row .name{font-weight:600}
+
+    .footer-actions{display:flex;gap:8px;margin-top:10px}
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <header>
+      <h1>Offene Posten</h1>
+      <div class="sub">Kunde · Rechnungsnr · Datum · Produkttyp · Betrag · Bisher gezahlt · Noch zu zahlen</div>
+    </header>
+
+    <section class="toolbar">
+      <input id="q" class="input" placeholder="Suche: Kunde, Rechnungsnr, Produkttyp…" />
+      <label class="muted" style="display:flex;align-items:center;gap:8px">Von <input id="from" type="date" class="input" /></label>
+      <label class="muted" style="display:flex;align-items:center;gap:8px">Bis <input id="to" type="date" class="input" /></label>
+      <select id="customer" title="Kunde">
+        <option value="">Alle Kunden</option>
+      </select>
+      <select id="ptype" title="Produkttyp">
+        <option value="">Alle Produkttypen</option>
+      </select>
+      <select id="status" title="Status">
+        <option value="">Alle</option>
+        <option value="overdue">Überfällig</option>
+        <option value="due7">Fällig ≤ 7 Tage</option>
+      </select>
+      <button id="reset" class="btn">Zurücksetzen</button>
+      <button id="exportCsv" class="btn">CSV Export</button>
+      <button id="exportPdf" class="btn primary">PDF Export</button>
+    </section>
+
+    <section class="grid grid-4" id="kpis">
+      <div class="kpi"><div class="label">Gesamtbetrag</div><div class="val" id="kpi-gross">€ 0,00</div></div>
+      <div class="kpi"><div class="label">Bisher gezahlt</div><div class="val" id="kpi-paid">€ 0,00</div></div>
+      <div class="kpi"><div class="label">Noch zu zahlen</div><div class="val" id="kpi-open">€ 0,00</div></div>
+      <div class="kpi"><div class="label">Überfällig</div><div class="val" id="kpi-overdue">€ 0,00</div></div>
+    </section>
+
+    <section class="layout" style="margin-top:16px">
+      <div class="card">
+        <h2>Rechnungen</h2>
+        <div class="body table">
+          <table id="tbl">
+            <thead>
+              <tr>
+                <th>Kunde</th>
+                <th>Rechnungsnr</th>
+                <th>Datum</th>
+                <th>Produkttyp</th>
+                <th class="right">Betrag Gesamt</th>
+                <th class="right">Bisher gezahlt</th>
+                <th class="right">Noch zu zahlen</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+        <div class="body muted" id="rowsum"></div>
+      </div>
+
+      <div class="card">
+        <h2>Totals je Kunde</h2>
+        <div class="body">
+          <div class="totals" id="totalsByCustomer"></div>
+          <div class="footer-actions">
+            <span class="pill warn">Überfällig</span>
+            <span class="pill">Fällig ≤ 7 Tage</span>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+  <script>
+    const EUR = new Intl.NumberFormat('de-DE',{style:'currency',currency:'EUR'});
+    const fmtDate = (d)=> new Date(d).toLocaleDateString('de-DE');
+    const addDays = (d,days)=>{const t=new Date(d); t.setDate(t.getDate()+days); return t;};
+
+    // Dummy-Daten – durch API/Backend ersetzen
+    const DATA = [
+      {customer:'Apotheke Sonnenschein', inv:'RE-250801', date:'2025-08-01', type:'Pods', gross:12480, paid:3000, due:'2025-08-31'},
+      {customer:'Apotheke Sonnenschein', inv:'RE-250812', date:'2025-08-12', type:'ELFLIQ', gross:20800, paid:0, due:'2025-09-11'},
+      {customer:'CityCare Apotheke', inv:'RE-250710', date:'2025-07-10', type:'EB600', gross:5200, paid:5200, due:'2025-08-09'},
+      {customer:'CityCare Apotheke', inv:'RE-250803', date:'2025-08-03', type:'EB800', gross:3120, paid:1000, due:'2025-09-02'},
+      {customer:'MediPlus Center', inv:'RE-250715', date:'2025-07-15', type:'Pods', gross:10400, paid:2000, due:'2025-08-14'},
+      {customer:'MediPlus Center', inv:'RE-250820', date:'2025-08-20', type:'EB600', gross:7800, paid:0, due:'2025-09-19'}
+    ];
+
+    const state = { q:'', from:'', to:'', customer:'', ptype:'', status:'' };
+
+    function money(n){return EUR.format(n||0)}
+    function within(d, from, to){ const t = +new Date(d); return (!from || t >= +new Date(from)) && (!to || t <= +new Date(to)+86400000-1); }
+    function daysUntil(date){ const diff = (+new Date(date) - Date.now())/(1000*60*60*24); return Math.floor(diff); }
+
+    function statusOf(row){
+      const open = Math.max((row.gross||0)-(row.paid||0),0);
+      if(open<=0) return '';
+      const days = daysUntil(row.due);
+      if(days < 0) return 'overdue';
+      if(days <= 7) return 'due7';
+      return '';
+    }
+
+    function buildFilters(){
+      const cSel = document.getElementById('customer');
+      const pSel = document.getElementById('ptype');
+      const customers = Array.from(new Set(DATA.map(r=>r.customer))).sort();
+      const types = Array.from(new Set(DATA.map(r=>r.type))).sort();
+      customers.forEach(c=>{ const o=document.createElement('option'); o.value=c; o.textContent=c; cSel.appendChild(o); });
+      types.forEach(t=>{ const o=document.createElement('option'); o.value=t; o.textContent=t; pSel.appendChild(o); });
+    }
+
+    function getFiltered(){
+      let rows = DATA.map(r=> ({...r, open: Math.max((r.gross||0)-(r.paid||0),0), stat: statusOf(r)}));
+      rows = rows.filter(r=>{
+        const txt = (r.customer+" "+r.inv+" "+r.type).toLowerCase();
+        const matches = !state.q || txt.includes(state.q.toLowerCase());
+        const inRange = within(r.date, state.from, state.to);
+        const cMatch = !state.customer || r.customer===state.customer;
+        const tMatch = !state.ptype || r.type===state.ptype;
+        const sMatch = !state.status || r.stat===state.status;
+        return matches && inRange && cMatch && tMatch && sMatch;
+      });
+      // Sort default: newest first
+      rows.sort((a,b)=> +new Date(b.date) - +new Date(a.date));
+      return rows;
+    }
+
+    function render(){
+      const rows = getFiltered();
+      const tb = document.querySelector('#tbl tbody');
+      tb.innerHTML = '';
+
+      let grossSum=0, paidSum=0, openSum=0, overdueSum=0;
+      const byCustomer = new Map();
+
+      rows.forEach(r=>{
+        grossSum += r.gross; paidSum += r.paid; openSum += r.open;
+        if(r.stat==='overdue') overdueSum += r.open;
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+          <td>${r.customer}</td>
+          <td>${r.inv}</td>
+          <td>${fmtDate(r.date)}</td>
+          <td>${r.type}</td>
+          <td class="right">${money(r.gross)}</td>
+          <td class="right">${money(r.paid)}</td>
+          <td class="right">${money(r.open)}</td>
+          <td>${r.stat==='overdue'?'<span class="pill danger">Überfällig</span>':(r.stat==='due7'?'<span class="pill warn">≤ 7 Tage</span>':'')}</td>`;
+        tb.appendChild(tr);
+
+        // Totals je Kunde
+        const t = byCustomer.get(r.customer) || {gross:0, paid:0, open:0};
+        t.gross += r.gross; t.paid += r.paid; t.open += r.open; byCustomer.set(r.customer, t);
+      });
+
+      document.getElementById('rowsum').textContent = `${rows.length} Rechnungen angezeigt`;
+      document.getElementById('kpi-gross').textContent = money(grossSum);
+      document.getElementById('kpi-paid').textContent = money(paidSum);
+      document.getElementById('kpi-open').textContent = money(openSum);
+      document.getElementById('kpi-overdue').textContent = money(overdueSum);
+
+      // Totals-Panel
+      const tp = document.getElementById('totalsByCustomer');
+      tp.innerHTML = '';
+      Array.from(byCustomer.entries())
+        .sort((a,b)=> b[1].open - a[1].open)
+        .forEach(([name,t])=>{
+          const row = document.createElement('div'); row.className='total-row';
+          row.innerHTML = `<span class="name">${name}</span><span class="muted">Gesamt: <strong>${money(t.gross)}</strong> · Gezahlt: <strong>${money(t.paid)}</strong> · Offen: <strong>${money(t.open)}</strong></span>`;
+          tp.appendChild(row);
+        });
+    }
+
+    function exportCSV(){
+      const rows = getFiltered();
+      const header = ['Kunde','Rechnungsnr','Datum','Produkttyp','Betrag Gesamt (EUR)','Bisher gezahlt (EUR)','Noch zu zahlen (EUR)','Status'];
+      const out = [header.join(';')].concat(rows.map(r=>[
+        r.customer, r.inv, r.date, r.type, r.gross.toFixed(2).replace('.',','), r.paid.toFixed(2).replace('.',','), r.open.toFixed(2).replace('.',','), r.stat
+      ].join(';'))).join('\n');
+      const blob = new Blob([out],{type:'text/csv;charset=utf-8;'});
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a'); a.href = url; a.download = 'offene_posten.csv'; a.click(); URL.revokeObjectURL(url);
+    }
+
+    function exportPDF(){
+      const { jsPDF } = window.jspdf; const doc = new jsPDF({unit:'pt',format:'a4'});
+      doc.setFontSize(14); doc.text('Offene Posten – Übersicht', 40, 40);
+      doc.setFontSize(10);
+      let y=64; doc.text('Kunde',40,y); doc.text('Rechnungsnr',170,y); doc.text('Datum',270,y); doc.text('Typ',330,y); doc.text('Gesamt',400,y); doc.text('Gezahlt',470,y); doc.text('Offen',530,y);
+      y+=12;
+      getFiltered().forEach(r=>{ if(y>780){ doc.addPage(); y=40; }
+        doc.text(r.customer,40,y); doc.text(r.inv,170,y); doc.text(fmtDate(r.date),270,y); doc.text(r.type,330,y);
+        doc.text((r.gross).toFixed(2)+' €',400,y,{align:'right'});
+        doc.text((r.paid).toFixed(2)+' €',470,y,{align:'right'});
+        doc.text((r.open).toFixed(2)+' €',530,y,{align:'right'}); y+=12; });
+      doc.save('offene_posten.pdf');
+    }
+
+    // Events
+    document.getElementById('q').addEventListener('input', e=>{state.q=e.target.value; render();});
+    document.getElementById('from').addEventListener('change', e=>{state.from=e.target.value; render();});
+    document.getElementById('to').addEventListener('change', e=>{state.to=e.target.value; render();});
+    document.getElementById('customer').addEventListener('change', e=>{state.customer=e.target.value; render();});
+    document.getElementById('ptype').addEventListener('change', e=>{state.ptype=e.target.value; render();});
+    document.getElementById('status').addEventListener('change', e=>{state.status=e.target.value; render();});
+    document.getElementById('reset').addEventListener('click', ()=>{
+      state.q='';state.from='';state.to='';state.customer='';state.ptype='';state.status='';
+      document.getElementById('q').value=''; document.getElementById('from').value=''; document.getElementById('to').value='';
+      document.getElementById('customer').value=''; document.getElementById('ptype').value=''; document.getElementById('status').value='';
+      render();
+    });
+    document.getElementById('exportCsv').addEventListener('click', exportCSV);
+    document.getElementById('exportPdf').addEventListener('click', exportPDF);
+
+    buildFilters();
+    render();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add standalone `offene-posten.html` page to display outstanding invoices with filters, KPIs, and export options

## Testing
- `npx -y htmlhint offene-posten.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*

------
https://chatgpt.com/codex/tasks/task_e_68a8075faa708327b9e3038cd219ff80