### PR TITLE
Add interactive opv shortcode for offene posten overview

### DIFF
--- a/wp-content/plugins/hoffmann-kundenportal/css/opv.css
+++ b/wp-content/plugins/hoffmann-kundenportal/css/opv.css
@@ -1,0 +1,35 @@
+:root{--bg:#f7fafc;--fg:#0f172a;--muted:#6b7280;--line:#e5e7eb;--card:#ffffff;--accent:#2563eb;--warn:#eab308;--danger:#dc2626;--ok:#16a34a;--radius:14px;--shadow:0 6px 24px rgba(2,6,23,.06)}
+*{box-sizing:border-box}
+#opv-root{max-width:1280px;margin:36px auto;padding:0 20px;color:var(--fg);background:var(--bg);font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial}
+#opv-root h1{margin:0 0 6px;font-size:28px;font-weight:700}
+#opv-root .sub{color:var(--muted);font-size:14px}
+#opv-root .toolbar{display:flex;flex-wrap:wrap;gap:10px;margin:18px 0}
+#opv-root .input,#opv-root select,#opv-root .btn{border:1px solid var(--line);background:#fff;border-radius:10px;height:40px;padding:8px 12px;font-size:14px}
+#opv-root .btn{cursor:pointer}
+#opv-root .btn.primary{background:var(--accent);border-color:var(--accent);color:#fff}
+#opv-root .grid{display:grid;gap:16px}
+#opv-root .grid-4{grid-template-columns:repeat(4,1fr)}
+@media (max-width:1024px){#opv-root .grid-4{grid-template-columns:repeat(2,1fr)}}
+@media (max-width:640px){#opv-root .grid-4{grid-template-columns:1fr}}
+#opv-root .kpi{background:var(--card);border:1px solid var(--line);border-radius:var(--radius);box-shadow:var(--shadow);padding:16px}
+#opv-root .kpi .label{font-size:12px;color:var(--muted)}
+#opv-root .kpi .val{font-size:22px;font-weight:700;margin-top:6px}
+#opv-root .layout{display:grid;grid-template-columns:2fr 1fr;gap:16px}
+@media (max-width:1024px){#opv-root .layout{grid-template-columns:1fr}}
+#opv-root .card{background:var(--card);border:1px solid var(--line);border-radius:var(--radius);box-shadow:var(--shadow)}
+#opv-root .card h2{margin:0;padding:14px 16px;border-bottom:1px solid var(--line);font-size:15px;color:#374151}
+#opv-root .card .body{padding:16px}
+#opv-root .table{overflow:auto;border-radius:var(--radius);border:1px solid var(--line);background:#fff}
+#opv-root table{width:100%;border-collapse:collapse;font-size:14px}
+#opv-root th,#opv-root td{padding:12px 14px;border-top:1px solid var(--line);text-align:left}
+#opv-root thead th{position:sticky;top:0;background:#f3f4f6;text-transform:uppercase;font-size:11px;letter-spacing:.06em;color:#6b7280;z-index:1}
+#opv-root tbody tr:nth-child(odd){background:#fbfdff}
+#opv-root .right{text-align:right}
+#opv-root .muted{color:var(--muted);font-size:13px}
+#opv-root .pill{display:inline-block;padding:4px 8px;border-radius:999px;border:1px solid var(--line);font-size:11px;color:#374151;background:#f8fafc}
+#opv-root .pill.warn{background:#fffbeb;border-color:#fde68a;color:#92400e}
+#opv-root .pill.danger{background:#fef2f2;border-color:#fecaca;color:#991b1b}
+#opv-root .totals{display:grid;grid-template-columns:1fr;gap:8px}
+#opv-root .total-row{display:flex;justify-content:space-between;align-items:center;border:1px solid var(--line);background:#fff;padding:10px 12px;border-radius:10px}
+#opv-root .total-row .name{font-weight:600}
+#opv-root .footer-actions{display:flex;gap:8px;margin-top:10px}

--- a/wp-content/plugins/hoffmann-kundenportal/hoffmann-opv.php
+++ b/wp-content/plugins/hoffmann-kundenportal/hoffmann-opv.php
@@ -265,3 +265,70 @@ add_shortcode('offene_posten_total', function() {
     <?php
     return ob_get_clean();
 });
+
+// Shortcode [opv] - interaktive Offene-Posten-Übersicht
+add_shortcode('opv', function() {
+    wp_enqueue_style('hoffmann-opv', plugins_url('css/opv.css', __FILE__));
+    wp_enqueue_script('jspdf', 'https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js', [], null, true);
+    wp_enqueue_script('hoffmann-opv', plugins_url('js/opv.js', __FILE__), ['jspdf'], null, true);
+    ob_start();
+    ?>
+    <div id="opv-root">
+      <header>
+        <h1>Offene Posten</h1>
+        <div class="sub">Kunde · Rechnungsnr · Datum · Produkttyp · Betrag · Bisher gezahlt · Noch zu zahlen</div>
+      </header>
+      <section class="toolbar">
+        <input id="opv-q" class="input" placeholder="Suche: Kunde, Rechnungsnr, Produkttyp…" />
+        <label class="muted" style="display:flex;align-items:center;gap:8px">Von <input id="opv-from" type="date" class="input" /></label>
+        <label class="muted" style="display:flex;align-items:center;gap:8px">Bis <input id="opv-to" type="date" class="input" /></label>
+        <select id="opv-customer" title="Kunde"><option value="">Alle Kunden</option></select>
+        <select id="opv-ptype" title="Produkttyp"><option value="">Alle Produkttypen</option></select>
+        <select id="opv-status" title="Status"><option value="">Alle</option><option value="overdue">Überfällig</option><option value="due7">Fällig ≤ 7 Tage</option></select>
+        <button id="opv-reset" class="btn">Zurücksetzen</button>
+        <button id="opv-exportCsv" class="btn">CSV Export</button>
+        <button id="opv-exportPdf" class="btn primary">PDF Export</button>
+      </section>
+      <section class="grid grid-4" id="opv-kpis">
+        <div class="kpi"><div class="label">Gesamtbetrag</div><div class="val" id="opv-kpi-gross">€ 0,00</div></div>
+        <div class="kpi"><div class="label">Bisher gezahlt</div><div class="val" id="opv-kpi-paid">€ 0,00</div></div>
+        <div class="kpi"><div class="label">Noch zu zahlen</div><div class="val" id="opv-kpi-open">€ 0,00</div></div>
+        <div class="kpi"><div class="label">Überfällig</div><div class="val" id="opv-kpi-overdue">€ 0,00</div></div>
+      </section>
+      <section class="layout" style="margin-top:16px">
+        <div class="card">
+          <h2>Rechnungen</h2>
+          <div class="body table">
+            <table id="opv-tbl">
+              <thead>
+                <tr>
+                  <th>Kunde</th>
+                  <th>Rechnungsnr</th>
+                  <th>Datum</th>
+                  <th>Produkttyp</th>
+                  <th class="right">Betrag Gesamt</th>
+                  <th class="right">Bisher gezahlt</th>
+                  <th class="right">Noch zu zahlen</th>
+                  <th>Status</th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
+          <div class="body muted" id="opv-rowsum"></div>
+        </div>
+        <div class="card">
+          <h2>Totals je Kunde</h2>
+          <div class="body">
+            <div class="totals" id="opv-totalsByCustomer"></div>
+            <div class="footer-actions">
+              <span class="pill warn">Überfällig</span>
+              <span class="pill">Fällig ≤ 7 Tage</span>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+    <?php
+    return ob_get_clean();
+});

--- a/wp-content/plugins/hoffmann-kundenportal/js/opv.js
+++ b/wp-content/plugins/hoffmann-kundenportal/js/opv.js
@@ -1,0 +1,142 @@
+(function(){
+  const EUR = new Intl.NumberFormat('de-DE',{style:'currency',currency:'EUR'});
+  const fmtDate = d => new Date(d).toLocaleDateString('de-DE');
+  const addDays = (d,days)=>{const t=new Date(d); t.setDate(t.getDate()+days); return t;};
+  let DATA = [];
+  const state = { q:'', from:'', to:'', customer:'', ptype:'', status:'' };
+  function money(n){return EUR.format(n||0)}
+  function within(d, from, to){ const t = +new Date(d); return (!from || t >= +new Date(from)) && (!to || t <= +new Date(to)+86400000-1); }
+  function daysUntil(date){ const diff = (+new Date(date) - Date.now())/(1000*60*60*24); return Math.floor(diff); }
+  function statusOf(row){
+    const open = Math.max((row.gross||0)-(row.paid||0),0);
+    if(open<=0 || !row.due) return '';
+    const days = daysUntil(row.due);
+    if(isNaN(days)) return '';
+    if(days < 0) return 'overdue';
+    if(days <= 7) return 'due7';
+    return '';
+  }
+  function buildFilters(){
+    const cSel = document.getElementById('opv-customer');
+    const pSel = document.getElementById('opv-ptype');
+    const customers = Array.from(new Set(DATA.map(r=>r.customer))).sort();
+    const types = Array.from(new Set(DATA.map(r=>r.type))).sort();
+    customers.forEach(c=>{ const o=document.createElement('option'); o.value=c; o.textContent=c; cSel.appendChild(o); });
+    types.forEach(t=>{ const o=document.createElement('option'); o.value=t; o.textContent=t; pSel.appendChild(o); });
+  }
+  function getFiltered(){
+    let rows = DATA.map(r=> ({...r, open: Math.max((r.gross||0)-(r.paid||0),0), stat: statusOf(r)}));
+    rows = rows.filter(r=>{
+      const txt = (r.customer+" "+r.inv+" "+r.type).toLowerCase();
+      const matches = !state.q || txt.includes(state.q.toLowerCase());
+      const inRange = within(r.date, state.from, state.to);
+      const cMatch = !state.customer || r.customer===state.customer;
+      const tMatch = !state.ptype || r.type===state.ptype;
+      const sMatch = !state.status || r.stat===state.status;
+      return matches && inRange && cMatch && tMatch && sMatch;
+    });
+    rows.sort((a,b)=> +new Date(b.date) - +new Date(a.date));
+    return rows;
+  }
+  function render(){
+    const rows = getFiltered();
+    const tb = document.querySelector('#opv-tbl tbody');
+    tb.innerHTML = '';
+    let grossSum=0, paidSum=0, openSum=0, overdueSum=0;
+    const byCustomer = new Map();
+    rows.forEach(r=>{
+      grossSum += r.gross; paidSum += r.paid; openSum += r.open;
+      if(r.stat==='overdue') overdueSum += r.open;
+      const tr = document.createElement('tr');
+      tr.innerHTML = `
+        <td>${r.customer}</td>
+        <td>${r.inv}</td>
+        <td>${fmtDate(r.date)}</td>
+        <td>${r.type}</td>
+        <td class="right">${money(r.gross)}</td>
+        <td class="right">${money(r.paid)}</td>
+        <td class="right">${money(r.open)}</td>
+        <td>${r.stat==='overdue'?'<span class="pill danger">Überfällig</span>':(r.stat==='due7'?'<span class="pill warn">≤ 7 Tage</span>':'')}</td>`;
+      tb.appendChild(tr);
+      const t = byCustomer.get(r.customer) || {gross:0, paid:0, open:0};
+      t.gross += r.gross; t.paid += r.paid; t.open += r.open; byCustomer.set(r.customer, t);
+    });
+    document.getElementById('opv-rowsum').textContent = `${rows.length} Rechnungen angezeigt`;
+    document.getElementById('opv-kpi-gross').textContent = money(grossSum);
+    document.getElementById('opv-kpi-paid').textContent = money(paidSum);
+    document.getElementById('opv-kpi-open').textContent = money(openSum);
+    document.getElementById('opv-kpi-overdue').textContent = money(overdueSum);
+    const tp = document.getElementById('opv-totalsByCustomer');
+    tp.innerHTML = '';
+    Array.from(byCustomer.entries()).sort((a,b)=> b[1].open - a[1].open).forEach(([name,t])=>{
+      const row = document.createElement('div'); row.className='total-row';
+      row.innerHTML = `<span class="name">${name}</span><span class="muted">Gesamt: <strong>${money(t.gross)}</strong> · Gezahlt: <strong>${money(t.paid)}</strong> · Offen: <strong>${money(t.open)}</strong></span>`;
+      tp.appendChild(row);
+    });
+  }
+  function exportCSV(){
+    const rows = getFiltered();
+    const header = ['Kunde','Rechnungsnr','Datum','Produkttyp','Betrag Gesamt (EUR)','Bisher gezahlt (EUR)','Noch zu zahlen (EUR)','Status'];
+    const out = [header.join(';')].concat(rows.map(r=>[
+      r.customer, r.inv, r.date, r.type, r.gross.toFixed(2).replace('.',','), r.paid.toFixed(2).replace('.',','), r.open.toFixed(2).replace('.',','), r.stat
+    ].join(';'))).join('\n');
+    const blob = new Blob([out],{type:'text/csv;charset=utf-8;'});
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a'); a.href = url; a.download = 'offene_posten.csv'; a.click(); URL.revokeObjectURL(url);
+  }
+  function exportPDF(){
+    const { jsPDF } = window.jspdf; const doc = new jsPDF({unit:'pt',format:'a4'});
+    doc.setFontSize(14); doc.text('Offene Posten – Übersicht', 40, 40);
+    doc.setFontSize(10);
+    let y=64; doc.text('Kunde',40,y); doc.text('Rechnungsnr',170,y); doc.text('Datum',270,y); doc.text('Typ',330,y); doc.text('Gesamt',400,y); doc.text('Gezahlt',470,y); doc.text('Offen',530,y);
+    y+=12;
+    getFiltered().forEach(r=>{ if(y>780){ doc.addPage(); y=40; }
+      doc.text(r.customer,40,y); doc.text(r.inv,170,y); doc.text(fmtDate(r.date),270,y); doc.text(r.type,330,y);
+      doc.text((r.gross).toFixed(2)+' €',400,y,{align:'right'});
+      doc.text((r.paid).toFixed(2)+' €',470,y,{align:'right'});
+      doc.text((r.open).toFixed(2)+' €',530,y,{align:'right'}); y+=12; });
+    doc.save('offene_posten.pdf');
+  }
+  function bindEvents(){
+    document.getElementById('opv-q').addEventListener('input', e=>{state.q=e.target.value; render();});
+    document.getElementById('opv-from').addEventListener('change', e=>{state.from=e.target.value; render();});
+    document.getElementById('opv-to').addEventListener('change', e=>{state.to=e.target.value; render();});
+    document.getElementById('opv-customer').addEventListener('change', e=>{state.customer=e.target.value; render();});
+    document.getElementById('opv-ptype').addEventListener('change', e=>{state.ptype=e.target.value; render();});
+    document.getElementById('opv-status').addEventListener('change', e=>{state.status=e.target.value; render();});
+    document.getElementById('opv-reset').addEventListener('click', ()=>{
+      state.q='';state.from='';state.to='';state.customer='';state.ptype='';state.status='';
+      document.getElementById('opv-q').value=''; document.getElementById('opv-from').value=''; document.getElementById('opv-to').value='';
+      document.getElementById('opv-customer').value=''; document.getElementById('opv-ptype').value=''; document.getElementById('opv-status').value='';
+      render();
+    });
+    document.getElementById('opv-exportCsv').addEventListener('click', exportCSV);
+    document.getElementById('opv-exportPdf').addEventListener('click', exportPDF);
+  }
+  function fetchData(){
+    const url = 'https://dashboard.hoffmann-hd.de/wp-content/uploads/json/offene_posten.json';
+    fetch(url)
+      .then(res => res.json())
+      .then(json => {
+        DATA = [];
+        Object.entries(json).forEach(([customer,rows])=>{
+          rows.forEach(r=>{
+            DATA.push({
+              customer,
+              inv: r['Rechnungsnr'],
+              date: r['Datum'],
+              type: r['Produkttyp'],
+              gross: parseFloat(r['Betrag Gesamt'])||0,
+              paid: parseFloat(r['Bisher gezahlt'])||0,
+              due: r['Faelligkeit'] || r['Fälligkeit'] || ''
+            });
+          });
+        });
+        buildFilters();
+        bindEvents();
+        render();
+      })
+      .catch(err=>console.error('OPV load error', err));
+  }
+  document.addEventListener('DOMContentLoaded', fetchData);
+})();


### PR DESCRIPTION
## Summary
- replace static Offene Posten page with `[opv]` shortcode that enqueues custom CSS/JS and jsPDF
- render searchable, filterable invoice table with KPI totals and export buttons
- load invoice data from JSON feed and compute per-customer totals and overdue amounts

## Testing
- `php -l wp-content/plugins/hoffmann-kundenportal/hoffmann-opv.php`
- `node --check wp-content/plugins/hoffmann-kundenportal/js/opv.js && echo 'syntax ok'`


------
https://chatgpt.com/codex/tasks/task_e_68a8075faa708327b9e3038cd219ff80