### PR TITLE
Fix unclosed brace in hoffmann-products

### DIFF
--- a/wp-content/plugins/hoffmann-kundenportal/hoffmann-products.php
+++ b/wp-content/plugins/hoffmann-kundenportal/hoffmann-products.php
@@ -155,6 +155,7 @@ function hoffmann_update_inventory() {
                 if ($info_changed) {
                     update_post_meta($post_id, 'information', $information);
                 }
+            }
             $meta_input = [
                 'artikelnummer' => $artikelnummer,
                 'bestand'       => $bestand,


### PR DESCRIPTION
## Summary
- fix missing closing brace in inventory update loop to resolve PHP parse error

## Testing
- `php -l wp-content/plugins/hoffmann-kundenportal/hoffmann-products.php`


------
https://chatgpt.com/codex/tasks/task_e_68a80b49980c83279d8ffbe16d7ce6e4