### PR TITLE
Fix exchange rate conversion for orders

### DIFF
--- a/wp-content/plugins/hoffmann-kundenportal/hoffmann-bestellungen-overview.php
+++ b/wp-content/plugins/hoffmann-kundenportal/hoffmann-bestellungen-overview.php
@@ -69,7 +69,7 @@ function hoffmann_bestellungen_overview_shortcode() {
             foreach ($products as $info){ $total_ordered += $info['ordered']; $total_warenwert_usd += $info['ordered']*$info['preis']; }
             $exchange_rate = hoffmann_to_float(get_post_meta($pid,'wechselkurs',true));
             if(!$exchange_rate){ $exchange_rate = 1.0; }
-            $total_warenwert_eur = $total_warenwert_usd * $exchange_rate;
+            $total_warenwert_eur = $total_warenwert_usd / $exchange_rate;
             $air_per_unit  = $total_ordered>0 ? $total_air/$total_ordered : 0;
             $zoll_per_unit = $total_ordered>0 ? $total_zoll/$total_ordered : 0;
             $stm_per_unit  = $total_ordered>0 ? $total_stm/$total_ordered : 0;

--- a/wp-content/plugins/hoffmann-kundenportal/hoffmann-bestellungen.php
+++ b/wp-content/plugins/hoffmann-kundenportal/hoffmann-bestellungen.php
@@ -618,10 +618,10 @@ function hoffmann_bestellung_single_content($content){
         $total_ordered   += $info['ordered'];
         $total_delivered += $info['delivered'];
         $total_warenwert_usd += $info['ordered'] * $info['preis'];
-        $info['preis'] = $info['preis'] * $exchange_rate;
+        $info['preis'] = $info['preis'] / $exchange_rate;
     }
     unset($info);
-    $total_warenwert = $total_warenwert_usd * $exchange_rate;
+    $total_warenwert = $total_warenwert_usd / $exchange_rate;
     $stm_posts = get_posts(array(
         'post_type'  => 'steuermarken',
         'numberposts'=> -1,


### PR DESCRIPTION
## Summary
- convert USD item prices to EUR by dividing through input exchange rate
- align overview page totals with new conversion logic

## Testing
- `php -l wp-content/plugins/hoffmann-kundenportal/hoffmann-bestellungen.php`
- `php -l wp-content/plugins/hoffmann-kundenportal/hoffmann-bestellungen-overview.php`


------
https://chatgpt.com/codex/tasks/task_e_68a878cbc67c8327a8e2c5eb2542f223