### PR TITLE
Show product prices in USD

### DIFF
--- a/wp-content/plugins/hoffmann-kundenportal/hoffmann-bestellungen.php
+++ b/wp-content/plugins/hoffmann-kundenportal/hoffmann-bestellungen.php
@@ -640,7 +640,6 @@ function hoffmann_bestellung_single_content($content){
         $total_ordered   += $info['ordered'];
         $total_delivered += $info['delivered'];
         $total_warenwert_usd += $info['ordered'] * $info['preis'];
-        $info['preis'] = $info['preis'] / $exchange_rate;
     }
     unset($info);
     $total_warenwert = $total_warenwert_usd / $exchange_rate;
@@ -819,7 +818,7 @@ function hoffmann_bestellung_single_content($content){
                     <th>SKU</th>
                     <th>Bestellt</th>
                     <th>Geliefert</th>
-                    <th>EK €/Stk</th>
+                    <th>EK $/Stk</th>
                 </tr>
             </thead>
             <tbody>
@@ -833,7 +832,7 @@ function hoffmann_bestellung_single_content($content){
                     <td><?php echo esc_html($art); ?></td>
                     <td><?php echo esc_html(number_format_i18n($info['ordered'])); ?></td>
                     <td><?php echo esc_html(number_format_i18n($info['delivered'])); ?></td>
-                    <td><?php echo esc_html(hoffmann_format_currency($info['preis'])); ?></td>
+                    <td>$<?php echo esc_html(hoffmann_format_currency($info['preis'])); ?></td>
 
                 </tr>
                 <?php endforeach; ?>


### PR DESCRIPTION
## Summary
- show product prices in USD instead of EUR by removing exchange-rate conversion and updating table labels

## Testing
- `php -l wp-content/plugins/hoffmann-kundenportal/hoffmann-bestellungen.php`

------
https://chatgpt.com/codex/tasks/task_e_68a8819aa13883278a8f459cc34dcde0