### PR TITLE
Add standalone PHP intranet system

### DIFF
--- a/intranet/.gitignore
+++ b/intranet/.gitignore
@@ -1,0 +1,1 @@
+intranet.db

--- a/intranet/config.php
+++ b/intranet/config.php
@@ -1,0 +1,4 @@
+<?php
+// Database connection using SQLite
+$pdo = new PDO('sqlite:' . __DIR__ . '/intranet.db');
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);

--- a/intranet/dashboard.php
+++ b/intranet/dashboard.php
@@ -1,0 +1,29 @@
+<?php
+session_start();
+if (!isset($_SESSION['username'])) {
+    header('Location: login.php');
+    exit();
+}
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Dashboard - Hofmann Intranet</title>
+</head>
+<body>
+<h2>Willkommen, <?php echo htmlspecialchars($_SESSION['username']); ?>!</h2>
+<p>Du bist als <strong><?php echo htmlspecialchars($_SESSION['role']); ?></strong> eingeloggt.</p>
+<nav>
+    <ul>
+        <?php if ($_SESSION['role'] === 'kunde'): ?>
+            <li><a href="kunde_area.php">Kundenbereich</a></li>
+        <?php endif; ?>
+        <?php if ($_SESSION['role'] === 'mitarbeiter'): ?>
+            <li><a href="mitarbeiter_area.php">Mitarbeiterbereich</a></li>
+        <?php endif; ?>
+        <li><a href="logout.php">Logout</a></li>
+    </ul>
+</nav>
+</body>
+</html>

--- a/intranet/init_db.php
+++ b/intranet/init_db.php
@@ -1,0 +1,24 @@
+<?php
+require __DIR__ . '/config.php';
+
+$pdo->exec('CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT UNIQUE NOT NULL,
+    password TEXT NOT NULL,
+    role TEXT NOT NULL
+)');
+
+// Insert initial users if not present
+$insert = $pdo->prepare('INSERT OR IGNORE INTO users (username, password, role) VALUES (:username, :password, :role)');
+$insert->execute([
+    ':username' => 'kunde1',
+    ':password' => password_hash('pass123', PASSWORD_DEFAULT),
+    ':role' => 'kunde'
+]);
+$insert->execute([
+    ':username' => 'mitarbeiter1',
+    ':password' => password_hash('admin456', PASSWORD_DEFAULT),
+    ':role' => 'mitarbeiter'
+]);
+
+echo "Database initialized.\n";

--- a/intranet/kunde_area.php
+++ b/intranet/kunde_area.php
@@ -1,0 +1,19 @@
+<?php
+session_start();
+if (!isset($_SESSION['username']) || $_SESSION['role'] !== 'kunde') {
+    header('Location: login.php?error=Keine+Zugriffsrechte');
+    exit();
+}
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Kundenbereich - Hofmann Intranet</title>
+</head>
+<body>
+<h2>Kundenbereich</h2>
+<p>Hier können Kunden ihre Inhalte sehen.</p>
+<a href="dashboard.php">Zurück zum Dashboard</a>
+</body>
+</html>

--- a/intranet/login.php
+++ b/intranet/login.php
@@ -1,0 +1,27 @@
+<?php
+session_start();
+if (isset($_SESSION['username'])) {
+    header('Location: dashboard.php');
+    exit();
+}
+$error = $_GET['error'] ?? '';
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Hofmann Intranet Login</title>
+</head>
+<body>
+<h2>Login - Hofmann Intranet</h2>
+<?php if ($error): ?>
+    <p style="color:red;"><?php echo htmlspecialchars($error); ?></p>
+<?php endif; ?>
+<form method="POST" action="login_process.php">
+    <label>Benutzername: <input type="text" name="username" required></label><br><br>
+    <label>Passwort: <input type="password" name="password" required></label><br><br>
+    <button type="submit">Einloggen</button>
+</form>
+<p>Noch keinen Zugang? <a href="register.php">Registrieren</a></p>
+</body>
+</html>

--- a/intranet/login_process.php
+++ b/intranet/login_process.php
@@ -1,0 +1,20 @@
+<?php
+session_start();
+require __DIR__ . '/config.php';
+
+$username = $_POST['username'] ?? '';
+$password = $_POST['password'] ?? '';
+
+$stmt = $pdo->prepare('SELECT username, password, role FROM users WHERE username = :username');
+$stmt->execute([':username' => $username]);
+$user = $stmt->fetch(PDO::FETCH_ASSOC);
+
+if ($user && password_verify($password, $user['password'])) {
+    $_SESSION['username'] = $user['username'];
+    $_SESSION['role'] = $user['role'];
+    header('Location: dashboard.php');
+    exit();
+}
+
+header('Location: login.php?error=Falsche+Login-Daten');
+exit();

--- a/intranet/logout.php
+++ b/intranet/logout.php
@@ -1,0 +1,6 @@
+<?php
+session_start();
+session_unset();
+session_destroy();
+header('Location: login.php');
+exit();

--- a/intranet/mitarbeiter_area.php
+++ b/intranet/mitarbeiter_area.php
@@ -1,0 +1,19 @@
+<?php
+session_start();
+if (!isset($_SESSION['username']) || $_SESSION['role'] !== 'mitarbeiter') {
+    header('Location: login.php?error=Keine+Zugriffsrechte');
+    exit();
+}
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Mitarbeiterbereich - Hofmann Intranet</title>
+</head>
+<body>
+<h2>Mitarbeiterbereich</h2>
+<p>Hier können Mitarbeiter interne Informationen abrufen.</p>
+<a href="dashboard.php">Zurück zum Dashboard</a>
+</body>
+</html>

--- a/intranet/register.php
+++ b/intranet/register.php
@@ -1,0 +1,51 @@
+<?php
+require __DIR__ . '/config.php';
+$success = '';
+$error = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $username = trim($_POST['username'] ?? '');
+    $password = $_POST['password'] ?? '';
+    $role = $_POST['role'] ?? 'kunde';
+
+    if ($username && $password) {
+        $stmt = $pdo->prepare('INSERT INTO users (username, password, role) VALUES (:username, :password, :role)');
+        try {
+            $stmt->execute([
+                ':username' => $username,
+                ':password' => password_hash($password, PASSWORD_DEFAULT),
+                ':role' => $role
+            ]);
+            $success = 'Nutzer erfolgreich angelegt.';
+        } catch (PDOException $e) {
+            $error = 'Benutzername bereits vergeben.';
+        }
+    } else {
+        $error = 'Alle Felder ausfüllen.';
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Registrierung - Hofmann Intranet</title>
+</head>
+<body>
+<h2>Registrierung</h2>
+<?php if ($success): ?><p style="color:green;"><?php echo htmlspecialchars($success); ?></p><?php endif; ?>
+<?php if ($error): ?><p style="color:red;"><?php echo htmlspecialchars($error); ?></p><?php endif; ?>
+<form method="POST">
+    <label>Benutzername: <input type="text" name="username" required></label><br><br>
+    <label>Passwort: <input type="password" name="password" required></label><br><br>
+    <label>Rolle:
+        <select name="role">
+            <option value="kunde">Kunde</option>
+            <option value="mitarbeiter">Mitarbeiter</option>
+        </select>
+    </label><br><br>
+    <button type="submit">Registrieren</button>
+</form>
+<p><a href="login.php">Zum Login</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add standalone PHP intranet with SQLite database
- Support user registration, login, and role-based dashboards
- Include customer and employee areas with secure sessions

## Testing
- `php -l intranet/config.php intranet/init_db.php intranet/login.php intranet/login_process.php intranet/register.php intranet/dashboard.php intranet/kunde_area.php intranet/mitarbeiter_area.php intranet/logout.php`
- `php intranet/init_db.php`


------
https://chatgpt.com/codex/tasks/task_e_68a8d4821f788327a9a1909c1dfc9907