### PR TITLE
Add JSON seeding and ticket system

### DIFF
--- a/intranet/.gitignore
+++ b/intranet/.gitignore
@@ -1,0 +1,1 @@
+intranet.db

--- a/intranet/admin_tickets.php
+++ b/intranet/admin_tickets.php
@@ -1,0 +1,94 @@
+<?php
+session_start();
+if (!isset($_SESSION['username']) || $_SESSION['role'] !== 'admin') {
+    header('Location: login.php?error=Keine+Zugriffsrechte');
+    exit();
+}
+require __DIR__ . '/config.php';
+
+if (isset($_POST['create'])) {
+    $title = trim($_POST['title'] ?? '');
+    $desc = trim($_POST['description'] ?? '');
+    $assigned = $_POST['assigned_to'] ?? '';
+    if ($title && $desc && $assigned) {
+        $stmt = $pdo->prepare('INSERT INTO tickets (title, description, status, assigned_to, created_by, created_at) VALUES (:title, :description, :status, :assigned_to, :created_by, :created_at)');
+        $stmt->execute([
+            ':title' => $title,
+            ':description' => $desc,
+            ':status' => 'open',
+            ':assigned_to' => $assigned,
+            ':created_by' => $_SESSION['username'],
+            ':created_at' => date('Y-m-d H:i:s')
+        ]);
+    }
+}
+
+if (isset($_POST['update'])) {
+    $id = (int)($_POST['id'] ?? 0);
+    $status = $_POST['status'] ?? 'open';
+    $stmt = $pdo->prepare('UPDATE tickets SET status = :status WHERE id = :id');
+    $stmt->execute([':status' => $status, ':id' => $id]);
+}
+
+$employees = $pdo->query("SELECT username FROM users WHERE role = 'mitarbeiter'")->fetchAll(PDO::FETCH_COLUMN);
+$tickets = $pdo->query('SELECT id, title, description, status, assigned_to FROM tickets')->fetchAll(PDO::FETCH_ASSOC);
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Ticket-Admin - Hofmann Intranet</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="container">
+    <h2 class="mb-4">Ticketverwaltung</h2>
+    <form method="POST" class="mb-4">
+        <input type="hidden" name="create" value="1">
+        <div class="mb-2">
+            <input type="text" name="title" class="form-control" placeholder="Titel" required>
+        </div>
+        <div class="mb-2">
+            <textarea name="description" class="form-control" placeholder="Beschreibung" required></textarea>
+        </div>
+        <div class="mb-2">
+            <select name="assigned_to" class="form-select" required>
+                <option value="">-- Mitarbeiter wählen --</option>
+                <?php foreach ($employees as $e): ?>
+                    <option value="<?php echo htmlspecialchars($e); ?>"><?php echo htmlspecialchars($e); ?></option>
+                <?php endforeach; ?>
+            </select>
+        </div>
+        <button class="btn btn-primary" type="submit">Ticket erstellen</button>
+    </form>
+    <table class="table table-striped">
+        <thead><tr><th>ID</th><th>Titel</th><th>Beschreibung</th><th>Mitarbeiter</th><th>Status</th><th>Aktion</th></tr></thead>
+        <tbody>
+            <?php foreach ($tickets as $t): ?>
+            <tr>
+                <td><?php echo $t['id']; ?></td>
+                <td><?php echo htmlspecialchars($t['title']); ?></td>
+                <td><?php echo htmlspecialchars($t['description']); ?></td>
+                <td><?php echo htmlspecialchars($t['assigned_to']); ?></td>
+                <td><?php echo htmlspecialchars($t['status']); ?></td>
+                <td>
+                    <form method="POST" class="d-flex">
+                        <input type="hidden" name="update" value="1">
+                        <input type="hidden" name="id" value="<?php echo $t['id']; ?>">
+                        <select name="status" class="form-select form-select-sm me-2">
+                            <option value="open" <?php if($t['status']==='open') echo 'selected'; ?>>Offen</option>
+                            <option value="in_progress" <?php if($t['status']==='in_progress') echo 'selected'; ?>>In Bearbeitung</option>
+                            <option value="done" <?php if($t['status']==='done') echo 'selected'; ?>>Erledigt</option>
+                        </select>
+                        <button class="btn btn-sm btn-primary" type="submit">Speichern</button>
+                    </form>
+                </td>
+            </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+    <a href="dashboard.php" class="btn btn-secondary">Zurück</a>
+</div>
+</body>
+</html>

--- a/intranet/bestand.json
+++ b/intranet/bestand.json
@@ -1,0 +1,4 @@
+[
+  {"artikel": "Buch", "bestand": 100},
+  {"artikel": "Stift", "bestand": 200}
+]

--- a/intranet/bestand.php
+++ b/intranet/bestand.php
@@ -1,0 +1,77 @@
+<?php
+session_start();
+if (!isset($_SESSION['username']) || !in_array($_SESSION['role'], ['mitarbeiter','admin'])) {
+    header('Location: login.php?error=Keine+Zugriffsrechte');
+    exit();
+}
+require __DIR__ . '/config.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $artikel = trim($_POST['artikel'] ?? '');
+    $bestand = (int)($_POST['bestand'] ?? 0);
+    if ($artikel && $bestand >= 0) {
+        $stmt = $pdo->prepare('INSERT INTO bestand (artikel, bestand) VALUES (:artikel, :bestand)');
+        $stmt->execute([
+            ':artikel' => $artikel,
+            ':bestand' => $bestand
+        ]);
+    }
+}
+$items = $pdo->query('SELECT id, artikel, bestand FROM bestand')->fetchAll(PDO::FETCH_ASSOC);
+if (!$items) {
+    $json = @file_get_contents('https://dashboard.hoffmann-hd.de/wp-content/uploads/json/bestand.json');
+    if (!$json) {
+        $file = __DIR__ . '/bestand.json';
+        $json = file_exists($file) ? file_get_contents($file) : '';
+    }
+    $data = json_decode($json, true);
+    if (is_array($data)) {
+        $stmt = $pdo->prepare('INSERT INTO bestand (artikel, bestand) VALUES (:artikel, :bestand)');
+        foreach ($data as $row) {
+            $stmt->execute([
+                ':artikel' => $row['artikel'] ?? '',
+                ':bestand' => (int)($row['bestand'] ?? 0)
+            ]);
+        }
+        $items = $pdo->query('SELECT id, artikel, bestand FROM bestand')->fetchAll(PDO::FETCH_ASSOC);
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Bestand - Hofmann Intranet</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="container">
+    <h2 class="mb-4">Bestand</h2>
+    <form method="POST" class="row g-2 mb-4">
+        <div class="col-md">
+            <input type="text" name="artikel" class="form-control" placeholder="Artikel" required>
+        </div>
+        <div class="col-md">
+            <input type="number" name="bestand" class="form-control" placeholder="Bestand" required>
+        </div>
+        <div class="col-md-auto">
+            <button class="btn btn-primary" type="submit">Hinzufügen</button>
+        </div>
+    </form>
+    <table class="table table-striped">
+        <thead><tr><th>ID</th><th>Artikel</th><th>Bestand</th></tr></thead>
+        <tbody>
+            <?php foreach ($items as $item): ?>
+            <tr>
+                <td><?php echo $item['id']; ?></td>
+                <td><?php echo htmlspecialchars($item['artikel']); ?></td>
+                <td><?php echo $item['bestand']; ?></td>
+            </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+    <a href="dashboard.php" class="btn btn-secondary">Zurück</a>
+</div>
+</body>
+</html>

--- a/intranet/bestellungen.json
+++ b/intranet/bestellungen.json
@@ -1,0 +1,4 @@
+[
+  {"kunde": "kunde1", "artikel": "Buch", "menge": 2},
+  {"kunde": "kunde2", "artikel": "Stift", "menge": 5}
+]

--- a/intranet/bestellungen.php
+++ b/intranet/bestellungen.php
@@ -1,0 +1,86 @@
+<?php
+session_start();
+if (!isset($_SESSION['username'])) {
+    header('Location: login.php?error=Keine+Zugriffsrechte');
+    exit();
+}
+require __DIR__ . '/config.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $kunde = $_SESSION['role'] === 'kunde' ? $_SESSION['username'] : trim($_POST['kunde'] ?? '');
+    $artikel = trim($_POST['artikel'] ?? '');
+    $menge = (int)($_POST['menge'] ?? 0);
+    if ($kunde && $artikel && $menge > 0) {
+        $stmt = $pdo->prepare('INSERT INTO bestellungen (kunde, artikel, menge) VALUES (:kunde, :artikel, :menge)');
+        $stmt->execute([
+            ':kunde' => $kunde,
+            ':artikel' => $artikel,
+            ':menge' => $menge
+        ]);
+    }
+}
+$orders = $pdo->query('SELECT id, kunde, artikel, menge FROM bestellungen')->fetchAll(PDO::FETCH_ASSOC);
+if (!$orders) {
+    $json = @file_get_contents('https://dashboard.hoffmann-hd.de/wp-content/uploads/json/bestellungen.json');
+    if (!$json) {
+        $file = __DIR__ . '/bestellungen.json';
+        $json = file_exists($file) ? file_get_contents($file) : '';
+    }
+    $data = json_decode($json, true);
+    if (is_array($data)) {
+        $stmt = $pdo->prepare('INSERT INTO bestellungen (kunde, artikel, menge) VALUES (:kunde, :artikel, :menge)');
+        foreach ($data as $row) {
+            $stmt->execute([
+                ':kunde' => $row['kunde'] ?? '',
+                ':artikel' => $row['artikel'] ?? '',
+                ':menge' => (int)($row['menge'] ?? 0)
+            ]);
+        }
+        $orders = $pdo->query('SELECT id, kunde, artikel, menge FROM bestellungen')->fetchAll(PDO::FETCH_ASSOC);
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Bestellungen - Hofmann Intranet</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="container">
+    <h2 class="mb-4">Bestellungen</h2>
+    <form method="POST" class="row g-2 mb-4">
+        <?php if ($_SESSION['role'] !== 'kunde'): ?>
+            <div class="col-md">
+                <input type="text" name="kunde" class="form-control" placeholder="Kunde" required>
+            </div>
+        <?php endif; ?>
+        <div class="col-md">
+            <input type="text" name="artikel" class="form-control" placeholder="Artikel" required>
+        </div>
+        <div class="col-md">
+            <input type="number" name="menge" class="form-control" placeholder="Menge" required>
+        </div>
+        <div class="col-md-auto">
+            <button class="btn btn-primary" type="submit">Hinzufügen</button>
+        </div>
+    </form>
+    <table class="table table-striped">
+        <thead><tr><th>ID</th><th>Kunde</th><th>Artikel</th><th>Menge</th></tr></thead>
+        <tbody>
+            <?php foreach ($orders as $order): ?>
+            <tr>
+                <td><?php echo $order['id']; ?></td>
+                <td><?php echo htmlspecialchars($order['kunde']); ?></td>
+                <td><?php echo htmlspecialchars($order['artikel']); ?></td>
+                <td><?php echo $order['menge']; ?></td>
+            </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+    <a href="dashboard.php" class="btn btn-secondary">Zurück</a>
+</div>
+</body>
+</html>

--- a/intranet/config.php
+++ b/intranet/config.php
@@ -1,0 +1,5 @@
+<?php
+// Database connection using SQLite. The database file "intranet.db"
+// is stored in the same directory as this configuration file.
+$pdo = new PDO('sqlite:' . __DIR__ . '/intranet.db');
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);

--- a/intranet/dashboard.php
+++ b/intranet/dashboard.php
@@ -1,0 +1,86 @@
+<?php
+session_start();
+if (!isset($_SESSION['username'])) {
+    header('Location: login.php');
+    exit();
+}
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Dashboard - Hofmann Intranet</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-light bg-light">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="#">Hofmann Intranet</a>
+        <div class="d-flex">
+            <span class="navbar-text me-3"><?php echo htmlspecialchars($_SESSION['username']); ?> (<?php echo htmlspecialchars($_SESSION['role']); ?>)</span>
+            <a class="btn btn-outline-danger" href="logout.php">Logout</a>
+        </div>
+    </div>
+</nav>
+<div class="container py-4">
+    <h2 class="mb-4">Dashboard</h2>
+    <div class="row g-4">
+        <?php if ($_SESSION['role'] === 'kunde'): ?>
+            <div class="col-md-4">
+                <a class="tile-link" href="kunde_area.php">
+                    <div class="card text-center h-100"><div class="card-body">Kundenbereich</div></div>
+                </a>
+            </div>
+            <div class="col-md-4">
+                <a class="tile-link" href="bestellungen.php">
+                    <div class="card text-center h-100"><div class="card-body">Bestellungen</div></div>
+                </a>
+            </div>
+            <div class="col-md-4">
+                <a class="tile-link" href="textbestellungen.php">
+                    <div class="card text-center h-100"><div class="card-body">Textbestellung</div></div>
+                </a>
+            </div>
+        <?php endif; ?>
+        <?php if (in_array($_SESSION['role'], ['mitarbeiter','admin'])): ?>
+            <div class="col-md-4">
+                <a class="tile-link" href="mitarbeiter_area.php">
+                    <div class="card text-center h-100"><div class="card-body">Mitarbeiterbereich</div></div>
+                </a>
+            </div>
+            <div class="col-md-4">
+                <a class="tile-link" href="steuermarken.php">
+                    <div class="card text-center h-100"><div class="card-body">Steuermarken</div></div>
+                </a>
+            </div>
+            <div class="col-md-4">
+                <a class="tile-link" href="bestellungen.php">
+                    <div class="card text-center h-100"><div class="card-body">Bestellungen</div></div>
+                </a>
+            </div>
+            <div class="col-md-4">
+                <a class="tile-link" href="textbestellungen.php">
+                    <div class="card text-center h-100"><div class="card-body">Textbestellung</div></div>
+                </a>
+            </div>
+            <div class="col-md-4">
+                <a class="tile-link" href="offene_posten.php">
+                    <div class="card text-center h-100"><div class="card-body">Offene Posten</div></div>
+                </a>
+            </div>
+            <div class="col-md-4">
+                <a class="tile-link" href="bestand.php">
+                    <div class="card text-center h-100"><div class="card-body">Bestand</div></div>
+                </a>
+            </div>
+            <div class="col-md-4">
+                <a class="tile-link" href="<?php echo $_SESSION['role']==='admin' ? 'admin_tickets.php' : 'tickets.php'; ?>">
+                    <div class="card text-center h-100"><div class="card-body">Tickets</div></div>
+                </a>
+            </div>
+        <?php endif; ?>
+    </div>
+</div>
+</body>
+</html>

--- a/intranet/init_db.php
+++ b/intranet/init_db.php
@@ -1,0 +1,141 @@
+<?php
+require __DIR__ . '/config.php';
+
+$pdo->exec('CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT UNIQUE NOT NULL,
+    password TEXT NOT NULL,
+    role TEXT NOT NULL
+)');
+
+$pdo->exec('CREATE TABLE IF NOT EXISTS steuermarken (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL
+)');
+
+$pdo->exec('CREATE TABLE IF NOT EXISTS bestand (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    artikel TEXT NOT NULL,
+    bestand INTEGER NOT NULL
+)');
+
+$pdo->exec('CREATE TABLE IF NOT EXISTS tickets (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title TEXT NOT NULL,
+    description TEXT NOT NULL,
+    status TEXT NOT NULL,
+    assigned_to TEXT NOT NULL,
+    created_by TEXT NOT NULL,
+    created_at TEXT NOT NULL
+)');
+
+$pdo->exec('CREATE TABLE IF NOT EXISTS bestellungen (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    kunde TEXT NOT NULL,
+    artikel TEXT NOT NULL,
+    menge INTEGER NOT NULL
+)');
+
+$pdo->exec('CREATE TABLE IF NOT EXISTS offene_posten (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    beschreibung TEXT NOT NULL,
+    betrag REAL NOT NULL
+)');
+
+$pdo->exec('CREATE TABLE IF NOT EXISTS textbestellungen (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    kunde TEXT NOT NULL,
+    text TEXT NOT NULL
+)');
+
+// Insert initial users if not present
+$insert = $pdo->prepare('INSERT OR IGNORE INTO users (username, password, role) VALUES (:username, :password, :role)');
+$insert->execute([
+    ':username' => 'mitarbeiter1',
+    ':password' => password_hash('admin456', PASSWORD_DEFAULT),
+    ':role' => 'mitarbeiter'
+]);
+$insert->execute([
+    ':username' => 'admin',
+    ':password' => password_hash('admin', PASSWORD_DEFAULT),
+    ':role' => 'admin'
+]);
+
+// Load customers from JSON
+$json = @file_get_contents('https://dashboard.hoffmann-hd.de/wp-content/uploads/json/kunden.json');
+if (!$json) {
+    $file = __DIR__ . '/kunden.json';
+    $json = file_exists($file) ? file_get_contents($file) : '';
+}
+$customers = json_decode($json, true);
+if (is_array($customers)) {
+    foreach ($customers as $c) {
+        if (!empty($c['username']) && !empty($c['password'])) {
+            $insert->execute([
+                ':username' => $c['username'],
+                ':password' => password_hash($c['password'], PASSWORD_DEFAULT),
+                ':role' => $c['role'] ?? 'kunde'
+            ]);
+        }
+    }
+}
+
+// Load orders from JSON if table is empty
+if (!$pdo->query('SELECT 1 FROM bestellungen LIMIT 1')->fetch()) {
+    $json = @file_get_contents('https://dashboard.hoffmann-hd.de/wp-content/uploads/json/bestellungen.json');
+    if (!$json) {
+        $file = __DIR__ . '/bestellungen.json';
+        $json = file_exists($file) ? file_get_contents($file) : '';
+    }
+    $data = json_decode($json, true);
+    if (is_array($data)) {
+        $stmt = $pdo->prepare('INSERT INTO bestellungen (kunde, artikel, menge) VALUES (:kunde, :artikel, :menge)');
+        foreach ($data as $row) {
+            $stmt->execute([
+                ':kunde' => $row['kunde'] ?? '',
+                ':artikel' => $row['artikel'] ?? '',
+                ':menge' => (int)($row['menge'] ?? 0)
+            ]);
+        }
+    }
+}
+
+// Load open items from JSON if table is empty
+if (!$pdo->query('SELECT 1 FROM offene_posten LIMIT 1')->fetch()) {
+    $json = @file_get_contents('https://dashboard.hoffmann-hd.de/wp-content/uploads/json/offene_posten.json');
+    if (!$json) {
+        $file = __DIR__ . '/offene_posten.json';
+        $json = file_exists($file) ? file_get_contents($file) : '';
+    }
+    $data = json_decode($json, true);
+    if (is_array($data)) {
+        $stmt = $pdo->prepare('INSERT INTO offene_posten (beschreibung, betrag) VALUES (:beschreibung, :betrag)');
+        foreach ($data as $row) {
+            $stmt->execute([
+                ':beschreibung' => $row['beschreibung'] ?? '',
+                ':betrag' => (float)($row['betrag'] ?? 0)
+            ]);
+        }
+    }
+}
+
+// Load inventory from JSON if table is empty
+if (!$pdo->query('SELECT 1 FROM bestand LIMIT 1')->fetch()) {
+    $json = @file_get_contents('https://dashboard.hoffmann-hd.de/wp-content/uploads/json/bestand.json');
+    if (!$json) {
+        $file = __DIR__ . '/bestand.json';
+        $json = file_exists($file) ? file_get_contents($file) : '';
+    }
+    $data = json_decode($json, true);
+    if (is_array($data)) {
+        $stmt = $pdo->prepare('INSERT INTO bestand (artikel, bestand) VALUES (:artikel, :bestand)');
+        foreach ($data as $row) {
+            $stmt->execute([
+                ':artikel' => $row['artikel'] ?? '',
+                ':bestand' => (int)($row['bestand'] ?? 0)
+            ]);
+        }
+    }
+}
+
+echo "Database initialized.\n";

--- a/intranet/kunde_area.php
+++ b/intranet/kunde_area.php
@@ -1,0 +1,25 @@
+<?php
+session_start();
+if (!isset($_SESSION['username']) || $_SESSION['role'] !== 'kunde') {
+    header('Location: login.php?error=Keine+Zugriffsrechte');
+    exit();
+}
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Kundenbereich - Hofmann Intranet</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="container">
+    <div class="card shadow p-4">
+        <h2 class="mb-4">Kundenbereich</h2>
+        <p>Hier können Kunden ihre Inhalte sehen.</p>
+        <a href="dashboard.php" class="btn btn-secondary">Zurück zum Dashboard</a>
+    </div>
+</div>
+</body>
+</html>

--- a/intranet/kunden.json
+++ b/intranet/kunden.json
@@ -1,0 +1,4 @@
+[
+  {"username": "kunde1", "password": "pass123"},
+  {"username": "kunde2", "password": "pass456"}
+]

--- a/intranet/login.php
+++ b/intranet/login.php
@@ -1,0 +1,39 @@
+<?php
+session_start();
+if (isset($_SESSION['username'])) {
+    header('Location: dashboard.php');
+    exit();
+}
+$error = $_GET['error'] ?? '';
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Hofmann Intranet Login</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="container">
+    <div class="card shadow p-4">
+        <h2 class="mb-4 text-center">Login</h2>
+        <?php if ($error): ?>
+            <div class="alert alert-danger"><?php echo htmlspecialchars($error); ?></div>
+        <?php endif; ?>
+        <form method="POST" action="login_process.php">
+            <div class="mb-3">
+                <label class="form-label">Benutzername</label>
+                <input type="text" name="username" class="form-control" required>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Passwort</label>
+                <input type="password" name="password" class="form-control" required>
+            </div>
+            <button type="submit" class="btn btn-primary w-100">Einloggen</button>
+        </form>
+        <p class="mt-3 text-center">Noch keinen Zugang? <a href="register.php">Registrieren</a></p>
+    </div>
+</div>
+</body>
+</html>

--- a/intranet/login_process.php
+++ b/intranet/login_process.php
@@ -1,0 +1,20 @@
+<?php
+session_start();
+require __DIR__ . '/config.php';
+
+$username = $_POST['username'] ?? '';
+$password = $_POST['password'] ?? '';
+
+$stmt = $pdo->prepare('SELECT username, password, role FROM users WHERE username = :username');
+$stmt->execute([':username' => $username]);
+$user = $stmt->fetch(PDO::FETCH_ASSOC);
+
+if ($user && password_verify($password, $user['password'])) {
+    $_SESSION['username'] = $user['username'];
+    $_SESSION['role'] = $user['role'];
+    header('Location: dashboard.php');
+    exit();
+}
+
+header('Location: login.php?error=Falsche+Login-Daten');
+exit();

--- a/intranet/logout.php
+++ b/intranet/logout.php
@@ -1,0 +1,6 @@
+<?php
+session_start();
+session_unset();
+session_destroy();
+header('Location: login.php');
+exit();

--- a/intranet/mitarbeiter_area.php
+++ b/intranet/mitarbeiter_area.php
@@ -1,0 +1,25 @@
+<?php
+session_start();
+if (!isset($_SESSION['username']) || !in_array($_SESSION['role'], ['mitarbeiter','admin'])) {
+    header('Location: login.php?error=Keine+Zugriffsrechte');
+    exit();
+}
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Mitarbeiterbereich - Hofmann Intranet</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="container">
+    <div class="card shadow p-4">
+        <h2 class="mb-4">Mitarbeiterbereich</h2>
+        <p>Hier können Mitarbeiter interne Informationen abrufen.</p>
+        <a href="dashboard.php" class="btn btn-secondary">Zurück zum Dashboard</a>
+    </div>
+</div>
+</body>
+</html>

--- a/intranet/offene_posten.json
+++ b/intranet/offene_posten.json
@@ -1,0 +1,4 @@
+[
+  {"beschreibung": "Rechnung 1001", "betrag": 120.5},
+  {"beschreibung": "Rechnung 1002", "betrag": 80}
+]

--- a/intranet/offene_posten.php
+++ b/intranet/offene_posten.php
@@ -1,0 +1,77 @@
+<?php
+session_start();
+if (!isset($_SESSION['username']) || !in_array($_SESSION['role'], ['mitarbeiter','admin'])) {
+    header('Location: login.php?error=Keine+Zugriffsrechte');
+    exit();
+}
+require __DIR__ . '/config.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $beschreibung = trim($_POST['beschreibung'] ?? '');
+    $betrag = (float)($_POST['betrag'] ?? 0);
+    if ($beschreibung && $betrag > 0) {
+        $stmt = $pdo->prepare('INSERT INTO offene_posten (beschreibung, betrag) VALUES (:beschreibung, :betrag)');
+        $stmt->execute([
+            ':beschreibung' => $beschreibung,
+            ':betrag' => $betrag
+        ]);
+    }
+}
+$items = $pdo->query('SELECT id, beschreibung, betrag FROM offene_posten')->fetchAll(PDO::FETCH_ASSOC);
+if (!$items) {
+    $json = @file_get_contents('https://dashboard.hoffmann-hd.de/wp-content/uploads/json/offene_posten.json');
+    if (!$json) {
+        $file = __DIR__ . '/offene_posten.json';
+        $json = file_exists($file) ? file_get_contents($file) : '';
+    }
+    $data = json_decode($json, true);
+    if (is_array($data)) {
+        $stmt = $pdo->prepare('INSERT INTO offene_posten (beschreibung, betrag) VALUES (:beschreibung, :betrag)');
+        foreach ($data as $row) {
+            $stmt->execute([
+                ':beschreibung' => $row['beschreibung'] ?? '',
+                ':betrag' => (float)($row['betrag'] ?? 0)
+            ]);
+        }
+        $items = $pdo->query('SELECT id, beschreibung, betrag FROM offene_posten')->fetchAll(PDO::FETCH_ASSOC);
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Offene Posten - Hofmann Intranet</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="container">
+    <h2 class="mb-4">Offene Posten</h2>
+    <form method="POST" class="row g-2 mb-4">
+        <div class="col-md">
+            <input type="text" name="beschreibung" class="form-control" placeholder="Beschreibung" required>
+        </div>
+        <div class="col-md">
+            <input type="number" step="0.01" name="betrag" class="form-control" placeholder="Betrag" required>
+        </div>
+        <div class="col-md-auto">
+            <button class="btn btn-primary" type="submit">Hinzufügen</button>
+        </div>
+    </form>
+    <table class="table table-striped">
+        <thead><tr><th>ID</th><th>Beschreibung</th><th>Betrag</th></tr></thead>
+        <tbody>
+            <?php foreach ($items as $item): ?>
+            <tr>
+                <td><?php echo $item['id']; ?></td>
+                <td><?php echo htmlspecialchars($item['beschreibung']); ?></td>
+                <td><?php echo number_format($item['betrag'], 2, ',', '.'); ?> €</td>
+            </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+    <a href="dashboard.php" class="btn btn-secondary">Zurück</a>
+</div>
+</body>
+</html>

--- a/intranet/register.php
+++ b/intranet/register.php
@@ -1,0 +1,64 @@
+<?php
+require __DIR__ . '/config.php';
+$success = '';
+$error = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $username = trim($_POST['username'] ?? '');
+    $password = $_POST['password'] ?? '';
+    $role = $_POST['role'] ?? 'kunde';
+
+    if ($username && $password) {
+        $stmt = $pdo->prepare('INSERT INTO users (username, password, role) VALUES (:username, :password, :role)');
+        try {
+            $stmt->execute([
+                ':username' => $username,
+                ':password' => password_hash($password, PASSWORD_DEFAULT),
+                ':role' => $role
+            ]);
+            $success = 'Nutzer erfolgreich angelegt.';
+        } catch (PDOException $e) {
+            $error = 'Benutzername bereits vergeben.';
+        }
+    } else {
+        $error = 'Alle Felder ausfüllen.';
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Registrierung - Hofmann Intranet</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="container">
+    <div class="card shadow p-4">
+        <h2 class="mb-4 text-center">Registrierung</h2>
+        <?php if ($success): ?><div class="alert alert-success"><?php echo htmlspecialchars($success); ?></div><?php endif; ?>
+        <?php if ($error): ?><div class="alert alert-danger"><?php echo htmlspecialchars($error); ?></div><?php endif; ?>
+        <form method="POST">
+            <div class="mb-3">
+                <label class="form-label">Benutzername</label>
+                <input type="text" name="username" class="form-control" required>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Passwort</label>
+                <input type="password" name="password" class="form-control" required>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Rolle</label>
+                <select name="role" class="form-select">
+                    <option value="kunde">Kunde</option>
+                    <option value="mitarbeiter">Mitarbeiter</option>
+                </select>
+            </div>
+            <button type="submit" class="btn btn-primary w-100">Registrieren</button>
+        </form>
+        <p class="mt-3 text-center"><a href="login.php">Zum Login</a></p>
+    </div>
+</div>
+</body>
+</html>

--- a/intranet/steuermarken.php
+++ b/intranet/steuermarken.php
@@ -1,0 +1,46 @@
+<?php
+session_start();
+if (!isset($_SESSION['username']) || !in_array($_SESSION['role'], ['mitarbeiter','admin'])) {
+    header('Location: login.php?error=Keine+Zugriffsrechte');
+    exit();
+}
+require __DIR__ . '/config.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name = trim($_POST['name'] ?? '');
+    if ($name) {
+        $stmt = $pdo->prepare('INSERT INTO steuermarken (name) VALUES (:name)');
+        $stmt->execute([':name' => $name]);
+    }
+}
+$marks = $pdo->query('SELECT id, name FROM steuermarken')->fetchAll(PDO::FETCH_ASSOC);
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Steuermarken - Hofmann Intranet</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="container">
+    <h2 class="mb-4">Steuermarken</h2>
+    <form method="POST" class="mb-4">
+        <div class="input-group">
+            <input type="text" name="name" class="form-control" placeholder="Bezeichnung" required>
+            <button class="btn btn-primary" type="submit">Hinzufügen</button>
+        </div>
+    </form>
+    <table class="table table-striped">
+        <thead><tr><th>ID</th><th>Name</th></tr></thead>
+        <tbody>
+            <?php foreach ($marks as $mark): ?>
+            <tr><td><?php echo $mark['id']; ?></td><td><?php echo htmlspecialchars($mark['name']); ?></td></tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+    <a href="dashboard.php" class="btn btn-secondary">Zurück</a>
+</div>
+</body>
+</html>

--- a/intranet/style.css
+++ b/intranet/style.css
@@ -1,0 +1,23 @@
+body {
+    background-color: #f8f9fa;
+}
+.card {
+    max-width: 500px;
+    margin: 2rem auto;
+}
+.container {
+    margin-top: 2rem;
+}
+
+.tile-link {
+    text-decoration: none;
+    color: inherit;
+}
+
+.tile-link .card {
+    transition: box-shadow .2s ease-in-out;
+}
+
+.tile-link .card:hover {
+    box-shadow: 0 0.5rem 1rem rgba(0,0,0,.15);
+}

--- a/intranet/textbestellungen.php
+++ b/intranet/textbestellungen.php
@@ -1,0 +1,62 @@
+<?php
+session_start();
+if (!isset($_SESSION['username'])) {
+    header('Location: login.php?error=Keine+Zugriffsrechte');
+    exit();
+}
+require __DIR__ . '/config.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $kunde = $_SESSION['role'] === 'kunde' ? $_SESSION['username'] : trim($_POST['kunde'] ?? '');
+    $text = trim($_POST['text'] ?? '');
+    if ($kunde && $text) {
+        $stmt = $pdo->prepare('INSERT INTO textbestellungen (kunde, text) VALUES (:kunde, :text)');
+        $stmt->execute([
+            ':kunde' => $kunde,
+            ':text' => $text
+        ]);
+    }
+}
+
+$entries = $pdo->query('SELECT id, kunde, text FROM textbestellungen')->fetchAll(PDO::FETCH_ASSOC);
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Textbestellung - Hofmann Intranet</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="container">
+    <h2 class="mb-4">Textbestellung</h2>
+    <form method="POST" class="row g-2 mb-4">
+        <?php if ($_SESSION['role'] !== 'kunde'): ?>
+            <div class="col-md">
+                <input type="text" name="kunde" class="form-control" placeholder="Kunde" required>
+            </div>
+        <?php endif; ?>
+        <div class="col-md">
+            <input type="text" name="text" class="form-control" placeholder="Bestellungstext" required>
+        </div>
+        <div class="col-md-auto">
+            <button class="btn btn-primary" type="submit">Hinzufügen</button>
+        </div>
+    </form>
+    <table class="table table-striped">
+        <thead><tr><th>ID</th><th>Kunde</th><th>Text</th></tr></thead>
+        <tbody>
+            <?php foreach ($entries as $e): ?>
+            <tr>
+                <td><?php echo $e['id']; ?></td>
+                <td><?php echo htmlspecialchars($e['kunde']); ?></td>
+                <td><?php echo htmlspecialchars($e['text']); ?></td>
+            </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+    <a href="dashboard.php" class="btn btn-secondary">Zurück</a>
+</div>
+</body>
+</html>

--- a/intranet/tickets.php
+++ b/intranet/tickets.php
@@ -1,0 +1,87 @@
+<?php
+session_start();
+if (!isset($_SESSION['username']) || !in_array($_SESSION['role'], ['mitarbeiter','admin'])) {
+    header('Location: login.php?error=Keine+Zugriffsrechte');
+    exit();
+}
+require __DIR__ . '/config.php';
+
+$username = $_SESSION['username'];
+
+if (isset($_POST['create'])) {
+    $title = trim($_POST['title'] ?? '');
+    $desc = trim($_POST['description'] ?? '');
+    if ($title && $desc) {
+        $stmt = $pdo->prepare('INSERT INTO tickets (title, description, status, assigned_to, created_by, created_at) VALUES (:title, :description, :status, :assigned_to, :created_by, :created_at)');
+        $stmt->execute([
+            ':title' => $title,
+            ':description' => $desc,
+            ':status' => 'open',
+            ':assigned_to' => $username,
+            ':created_by' => $username,
+            ':created_at' => date('Y-m-d H:i:s')
+        ]);
+    }
+}
+
+if (isset($_POST['update'])) {
+    $id = (int)($_POST['id'] ?? 0);
+    $status = $_POST['status'] ?? 'open';
+    $stmt = $pdo->prepare('UPDATE tickets SET status = :status WHERE id = :id AND assigned_to = :user');
+    $stmt->execute([':status' => $status, ':id' => $id, ':user' => $username]);
+}
+
+$tickets = $pdo->prepare('SELECT id, title, description, status FROM tickets WHERE assigned_to = :user');
+$tickets->execute([':user' => $username]);
+$items = $tickets->fetchAll(PDO::FETCH_ASSOC);
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Tickets - Hofmann Intranet</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="container">
+    <h2 class="mb-4">Meine Tickets</h2>
+    <form method="POST" class="mb-4">
+        <input type="hidden" name="create" value="1">
+        <div class="mb-2">
+            <input type="text" name="title" class="form-control" placeholder="Titel" required>
+        </div>
+        <div class="mb-2">
+            <textarea name="description" class="form-control" placeholder="Beschreibung" required></textarea>
+        </div>
+        <button class="btn btn-primary" type="submit">Ticket erstellen</button>
+    </form>
+    <table class="table table-striped">
+        <thead><tr><th>ID</th><th>Titel</th><th>Beschreibung</th><th>Status</th><th>Aktion</th></tr></thead>
+        <tbody>
+            <?php foreach ($items as $t): ?>
+            <tr>
+                <td><?php echo $t['id']; ?></td>
+                <td><?php echo htmlspecialchars($t['title']); ?></td>
+                <td><?php echo htmlspecialchars($t['description']); ?></td>
+                <td><?php echo htmlspecialchars($t['status']); ?></td>
+                <td>
+                    <form method="POST" class="d-flex">
+                        <input type="hidden" name="update" value="1">
+                        <input type="hidden" name="id" value="<?php echo $t['id']; ?>">
+                        <select name="status" class="form-select form-select-sm me-2">
+                            <option value="open" <?php if($t['status']==='open') echo 'selected'; ?>>Offen</option>
+                            <option value="in_progress" <?php if($t['status']==='in_progress') echo 'selected'; ?>>In Bearbeitung</option>
+                            <option value="done" <?php if($t['status']==='done') echo 'selected'; ?>>Erledigt</option>
+                        </select>
+                        <button class="btn btn-sm btn-primary" type="submit">Speichern</button>
+                    </form>
+                </td>
+            </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+    <a href="dashboard.php" class="btn btn-secondary">Zurück</a>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Seed customers, orders, open items and inventory from provided JSON with local fallbacks
- Introduce inventory management page and ticket system with employee and admin views
- Expand dashboard with links to inventory and ticket management

## Testing
- `php -l intranet/config.php intranet/init_db.php intranet/login.php intranet/login_process.php intranet/register.php intranet/dashboard.php intranet/kunde_area.php intranet/mitarbeiter_area.php intranet/logout.php intranet/steuermarken.php intranet/bestellungen.php intranet/offene_posten.php intranet/textbestellungen.php intranet/bestand.php intranet/tickets.php intranet/admin_tickets.php`
- `php intranet/init_db.php`
- `sqlite3 intranet/intranet.db "select * from bestellungen;" | head`
- `sqlite3 intranet/intranet.db "select * from offene_posten;" | head`
- `sqlite3 intranet/intranet.db "select * from bestand;" | head`
- `sqlite3 intranet/intranet.db "select username, role from users;" | head`
- `sqlite3 intranet/intranet.db ".tables"`


------
https://chatgpt.com/codex/tasks/task_e_68a8d4821f788327a9a1909c1dfc9907