### PR TITLE
feat: add order detail editing and modernize auth pages

### DIFF
--- a/intranet/bestellung_details.php
+++ b/intranet/bestellung_details.php
@@ -1,0 +1,108 @@
+<?php
+session_start();
+require __DIR__ . '/config.php';
+if (!isset($_SESSION['username'])) {
+    header('Location: login.php?error=Keine+Zugriffsrechte');
+    exit();
+}
+$orderNo = $_GET['id'] ?? '';
+if (!$orderNo) {
+    echo 'Keine Bestellung gewählt';
+    exit();
+}
+$rate = 1.08; // 1 EUR = 1.08 USD
+$currency = $_POST['currency'] ?? $_GET['currency'] ?? 'eur';
+// Fetch parent
+$stmt = $pdo->prepare('SELECT belegnummer, belegdatum, betreff, betrag FROM bestellungen WHERE belegnummer = ? AND belegart = 2200');
+$stmt->execute([$orderNo]);
+$parent = $stmt->fetch(PDO::FETCH_ASSOC);
+if (!$parent) {
+    echo 'Bestellung nicht gefunden';
+    exit();
+}
+// Fetch items
+$stmt = $pdo->prepare('SELECT belegnummer, betreff, betrag FROM bestellungen WHERE vorbelegnummer = ? AND belegart = 2900');
+$stmt->execute([$orderNo]);
+$items = $stmt->fetchAll(PDO::FETCH_ASSOC);
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    foreach ($items as $item) {
+        $field = 'price_' . $item['belegnummer'];
+        if (isset($_POST[$field])) {
+            $val = (float)$_POST[$field];
+            if ($currency === 'usd') {
+                $val = $val / $rate;
+            }
+            $upd = $pdo->prepare('UPDATE bestellungen SET betrag = ? WHERE belegnummer = ?');
+            $upd->execute([$val, $item['belegnummer']]);
+        }
+    }
+    $sum = $pdo->prepare('SELECT SUM(betrag) FROM bestellungen WHERE vorbelegnummer = ? AND belegart = 2900');
+    $sum->execute([$orderNo]);
+    $total = $sum->fetchColumn();
+    $upd = $pdo->prepare('UPDATE bestellungen SET betrag = ? WHERE belegnummer = ? AND belegart = 2200');
+    $upd->execute([$total, $orderNo]);
+    header('Location: bestellung_details.php?id=' . $orderNo . '&currency=' . $currency . '&saved=1');
+    exit();
+}
+function formatAmount($val, $currency, $rate) {
+    if ($currency === 'usd') {
+        return number_format($val * $rate, 2, '.', '');
+    }
+    return number_format($val, 2, '.', '');
+}
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Bestellung <?php echo htmlspecialchars($orderNo); ?></title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="silva-template/assets/app.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="container">
+    <div class="card shadow p-4">
+        <img src="img/hoffmann-logo-light.png" alt="Hoffmann" class="mb-4" style="max-width:200px;">
+        <h2 class="mb-4">Bestellung <?php echo htmlspecialchars($orderNo); ?></h2>
+        <?php if(isset($_GET['saved'])): ?>
+            <div class="alert alert-success">Änderungen gespeichert</div>
+        <?php endif; ?>
+        <form method="post">
+            <div class="mb-3">
+                <label class="form-label">Währung</label>
+                <select name="currency" id="currency" class="form-select">
+                    <option value="eur" <?php if($currency==='eur') echo 'selected'; ?>>EUR</option>
+                    <option value="usd" <?php if($currency==='usd') echo 'selected'; ?>>USD</option>
+                </select>
+            </div>
+            <table class="table">
+                <thead><tr><th>Artikel</th><th class="text-end">Preis</th></tr></thead>
+                <tbody>
+                <?php foreach ($items as $it): ?>
+                    <tr>
+                        <td><?php echo htmlspecialchars($it['betreff']); ?></td>
+                        <td class="text-end">
+                            <input type="number" step="0.01" class="form-control text-end price-input" name="price_<?php echo $it['belegnummer']; ?>" value="<?php echo formatAmount($it['betrag'],$currency,$rate); ?>" data-eur="<?php echo htmlspecialchars($it['betrag']); ?>">
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+                </tbody>
+            </table>
+            <button type="submit" class="btn btn-primary">Speichern</button>
+            <a href="bestellungen.php" class="btn btn-secondary">Zurück</a>
+        </form>
+    </div>
+</div>
+<script>
+const RATE=1.08;
+const cur=document.getElementById('currency');
+cur.addEventListener('change',e=>{
+  document.querySelectorAll('.price-input').forEach(inp=>{
+    const eur=parseFloat(inp.dataset.eur);
+    inp.value = e.target.value==='usd' ? (eur*RATE).toFixed(2) : eur.toFixed(2);
+  });
+});
+</script>
+</body>
+</html>

--- a/intranet/bestellungen.php
+++ b/intranet/bestellungen.php
@@ -130,12 +130,12 @@ function render(){
     const tr=document.createElement('tr');
     tr.classList.add('parent');
     tr.dataset.id=r.orderNo;
-    tr.innerHTML=`<td><strong>${r.title}</strong></td><td><span class="orderNo">${r.orderNo}</span></td><td>${new Date(r.orderedAt).toLocaleDateString('de-DE')}</td><td class="right">${EUR.format(r.betrag)}</td>`;
+    tr.innerHTML=`<td><strong>${r.title}</strong></td><td><a href="bestellung_details.php?id=${r.orderNo}" class="orderNo">${r.orderNo}</a></td><td>${new Date(r.orderedAt).toLocaleDateString('de-DE')}</td><td class="right">${EUR.format(r.betrag)}</td>`;
     tbody.appendChild(tr);
     r.children.forEach(c=>{
       const cr=document.createElement('tr');
       cr.classList.add('child',`child-${r.orderNo}`);
-      cr.innerHTML=`<td>↳ ${c.title}</td><td><span class="orderNo">${c.orderNo}</span></td><td>${new Date(c.orderedAt).toLocaleDateString('de-DE')}</td><td class="right">${EUR.format(c.betrag)}</td>`;
+      cr.innerHTML=`<td>↳ ${c.title}</td><td><a href="bestellung_details.php?id=${c.orderNo}" class="orderNo">${c.orderNo}</a></td><td>${new Date(c.orderedAt).toLocaleDateString('de-DE')}</td><td class="right">${EUR.format(c.betrag)}</td>`;
       tbody.appendChild(cr);
     });
   });

--- a/intranet/login.php
+++ b/intranet/login.php
@@ -12,11 +12,15 @@ $error = $_GET['error'] ?? '';
     <meta charset="UTF-8">
     <title>Hofmann Intranet Login</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="silva-template/assets/app.css">
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
 <div class="container">
     <div class="card shadow p-4">
+        <div class="text-center mb-4">
+            <img src="img/hoffmann-logo-light.png" alt="Hoffmann" style="max-width:200px;">
+        </div>
         <h2 class="mb-4 text-center">Login</h2>
         <?php if ($error): ?>
             <div class="alert alert-danger"><?php echo htmlspecialchars($error); ?></div>

--- a/intranet/logout.php
+++ b/intranet/logout.php
@@ -2,5 +2,24 @@
 session_start();
 session_unset();
 session_destroy();
-header('Location: login.php');
-exit();
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Abmeldung - Hofmann Intranet</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="silva-template/assets/app.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="container">
+    <div class="card shadow p-4 text-center">
+        <img src="img/hoffmann-logo-light.png" alt="Hoffmann" class="mb-4" style="max-width:200px;">
+        <h2>Sie wurden ausgeloggt</h2>
+        <p class="mb-4">Vielen Dank für Ihren Besuch.</p>
+        <a href="login.php" class="btn btn-primary">Zum Login</a>
+    </div>
+</div>
+</body>
+</html>

--- a/intranet/silva-template/assets/app.css
+++ b/intranet/silva-template/assets/app.css
@@ -1,0 +1,3 @@
+body{background:#f7fafc;font-family:system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;}
+.card{border:1px solid #e5e7eb;border-radius:0.75rem;box-shadow:0 6px 24px rgba(2,6,23,0.06);background:#fff;}
+.btn-primary{background-color:#2563eb;border-color:#2563eb;}


### PR DESCRIPTION
## Summary
- style login and logout with Hoffmann branding and Silva template styles
- link orders to new detail page with editable line item prices and USD option
- add lightweight Silva template stylesheet

## Testing
- `php -l intranet/login.php`
- `php -l intranet/logout.php`
- `php -l intranet/bestellungen.php`
- `php -l intranet/bestellung_details.php`


------
https://chatgpt.com/codex/tasks/task_e_68a96e0a54988327af371495514c256d